### PR TITLE
Update 020_ws3_model_example.ipynb

### DIFF
--- a/examples/020_ws3_model_example.ipynb
+++ b/examples/020_ws3_model_example.ipynb
@@ -4618,7 +4618,7 @@
     }
    ],
    "source": [
-    "fm.areaselector = GreedyAreaSelector(fm)"
+    "fm.areaselector = ws3.forest.GreedyAreaSelector(fm)"
    ]
   },
   {


### PR DESCRIPTION
The source 'ws3.forest.' should be added before the GreedyAreaSelector(fm) class to make this line and the rest of the codes run successfully. I don't know if you leave that on purpose.