### PR TITLE
Feature/libcbm optional dependency (#47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ Read the tutorial [here](https://ws3.readthedocs.io/en/latest/index.html).
 
 We recommend installing `ws3` package into a Python venv (virtual environment) to minimize interactions with system-level packages. 
 
+Optional CBM support available via `pip install libcbm`.
+
+Optional Gurobi support available via `pip install ws3[gurobi]` or `conda install -c gurobi gurobi`.
+
+Optional PuLP support available via `pip install pulp`.
+
 In [**000_venv_python_kernel_setup.ipynb**](https://github.com/UBC-FRESH/ws3/blob/dev/examples/000_venv_python_kernel_setup.ipynb) we provide the instructions for how to set up a new venv-sandboxed Python kernel and make it available in your JupyterLab environment, assuming that you are running this notebook in a standard linux-based environment and a regular (non-root) using running commands in a bash terminal. 
 
 ## Modules 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,11 +17,8 @@ dependencies = [
   "rasterio",
   "fiona",
   "profilehooks",
-  "libcbm",
-  "pulp",
   "dill",
-  "highspy",
-  "gurobipy"
+  "highspy"
 ]
 authors = [
   {name = "Gregory Paradis", email = "gregory.paradis@ubc.ca"}
@@ -31,6 +28,11 @@ maintainers = [
   {name = "Elaheh Ghasemi", email = "elaheh.ghasemi@ubc.ca"},
   {name = "Salar Ghotb", email = "salar.ghotb@ubc.ca"}
 ]
+
+[project.optional-dependencies]
+cbm = ["libcbm"]  # pip users can `pip install ws3[cbm]`
+gurobi = ["gurobipy"]
+pulp = ["pulp"]
 
 [tool.hatch.version]
 source = "code"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -23,3 +23,5 @@ sphinx_rtd_theme
 nbsphinx
 # furo
 
+# libcbm (to run some of the example notebooks)
+libcbm

--- a/ws3/__init__.py
+++ b/ws3/__init__.py
@@ -3,7 +3,7 @@ This is the :py:module::`ws3` Python package.
 .. moduleauthor:: Gregory Paradis gregory.paradis@ubc.ca
 """
 
-__version__ = '1.0.2'
+__version__ = '1.0.4'
 __all__ = ['common', 
            'core', 
            'util', 


### PR DESCRIPTION
* remove libcbm from pyproject.toml required deps list and move to optional deps list (so does not block publication on conda-forge)

* increment version to 1.0.3

* move gurobi and pulp deps to to optional, bump version to 1.0.4