### PR TITLE
Phase 7.6 — Defect sweep from mypy findings (v1.1.0a4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Common Changelog](https://common-changelog.org/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 1.1.0a4 - 2026-07-29 (alpha)
+
+**Status**: Defect sweep. Fixes a silent numerical error, restores probabilistic financial analysis, and gates code paths that returned meaningless results.
+
+### Fixed
+- **`sylv_cred` returned values wrong by ~40x, silently.** Seven of eight hand-copied binding pairs in `ws3/financial.py` bound `log` to `math.exp` rather than `math.log`, so `exp(C7d*log(vp)+C8d)` evaluated as `exp(C7d*exp(vp)+C8d)`. Only `harv_cost` was correct, which established the intent. Evaluated independently at `P=10, vr=2, vp=1`: correct `80.83076`, as-coded `126.33232`. The existing test asserted `126.33` — the buggy output — because it had been written by running the code and recording the result. The eight duplicated pairs are now a single `_math_funcs()` helper.
+- **All `rv=True` paths raised `NameError`.** `PACAL_BROKEN = True` guarded the `import pacal` permanently, so the name was never bound. Neither flake8 nor mypy could see it: pyflakes treats a guarded import as binding the name.
+- **Unguarded optional access in the Woodstock parsers.** 20 sites, mostly `re.search(...).group(...)`, which raise a bare `AttributeError` on malformed input. Now raise `ValueError` naming the construct, the expected pattern, and the offending text.
+
+### Changed
+- **PaCal support restored.** The standing note said to patch `numpy.fft.fftpack` in `pacal/utils.py`, but that describes PaCal 1.6 — 1.6.1 already imports from `numpy.fft`. The real blockers were NumPy 2.0 alias removals (`Inf`, `NaN`, `asfarray`, `product`) and an undeclared `sympy` dependency. A small additive compatibility shim makes PaCal 1.6.1 work on NumPy 2.5. Available via `pip install ws3[rv]`. PaCal is GPL-3.0-or-later while ws3 is MIT, so it remains an optional dependency the user installs and is never bundled.
+- **Non-functional Phase 5 code paths are gated.** Twelve entry points across `advanced_modeling`, `perf`, and `integration` now raise `NotImplementedError` naming what is missing, rather than returning fabricated results. Most seriously, `StochasticOptimizer.solve_stochastic` reported `expected_value`, `variance`, and `std_dev` while `_apply_scenario` was a bare `pass` — scenarios were generated and never applied, so the variance across N identical solves was always exactly 0. Data structures, scenario generation, `MemoryProfiler`, `ResultCache`, and benchmarking are unaffected and still work.
+- mypy's `warn_unused_ignores` disabled: with `ignore_missing_imports`, an absent optional dependency types as `Any`, so the check reports differently depending on whether PaCal is installed.
+
+### Added
+- `ws3[rv]` extra for probabilistic financial analysis.
+- `ws3.financial.pacal_available()`.
+- `tests/test_experimental_gates.py` — 29 tests asserting every gate fires with an actionable message and that the working parts still work.
+- Regression tests for the `log`/`exp` mixup and the parser error messages.
+
+### Notes
+Several existing tests asserted the defective behaviour and had to be rewritten. They built `MagicMock` problems whose `get_objective_value()` and `get_solution()` returned canned values — neither method exists on `ws3.opt.Problem`, but `MagicMock` supplies any attribute requested, so they passed against an API that was never written. One asserted `result["objective_values"] == {}`, pinning a stub's hardcoded empty dict as correct. Tests written by recording what the code returned cannot catch the defect they were born from.
+
 ## 1.1.0a3 - 2026-07-29 (alpha)
 
 **Status**: Patch release. Clears code-quality debt that was blocking meaningful CI signal, and fixes runtime defects shipped in 1.1.0a2.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -258,3 +258,43 @@ This roadmap tracks the current UBC-FRESH-style development workflow for ws3.
 ### Task 7.5.5 — Release v1.1.0a3
 - Status: complete
 - Scope: version bump, CHANGELOG, tag, PyPI publish via trusted publisher.
+
+## Backlog — not yet scheduled
+
+Phase-sized work identified during Phase 7.5 and deferred to keep that phase scoped.
+
+### Typing debt remediation
+- Issue: [#98](https://github.com/UBC-FRESH/ws3/issues/98)
+- Status: not_started
+- Scope: 323 mypy errors across 10 files (69% in `forest.py`) from the incomplete Phase 2 typed refactor. The mypy CI step is `continue-on-error` until this lands. Includes 20 `union-attr` findings that are unguarded `re.search(...).group()` calls, and 12 `attr-defined` findings, one of which is already confirmed as a real `ImportError` ([#97](https://github.com/UBC-FRESH/ws3/issues/97)). Staged plan in the issue.
+
+### Known defects
+- [#97](https://github.com/UBC-FRESH/ws3/issues/97) — `advanced_modeling` imports `ws3.core.compile_scenario`, which does not exist.
+
+## Phase 7.6 — Defect Sweep from mypy Findings
+
+- Parent issue: [#99](https://github.com/UBC-FRESH/ws3/issues/99)
+- Status: complete
+- Branch: `feature/ws3-phase7.6-defect-sweep`
+- Release: `v1.1.0a4`
+- Date: 2026-07-29
+
+**Goal**: fix the subset of mypy findings representing actual defects, so Phase 8 can build symbol-validating capabilities on a package that does not reference things that do not exist. Deliberately not the full 323-error typing debt ([#98](https://github.com/UBC-FRESH/ws3/issues/98)).
+
+| Class | Before | After |
+|---|---:|---:|
+| `attr-defined` | 12 | 0 |
+| `union-attr` | 20 | 0 |
+| `unused-ignore` | 34 | 0 |
+| mypy total | 323 | 258 |
+
+### Defects fixed
+- [#100](https://github.com/UBC-FRESH/ws3/issues/100) — `sylv_cred` bound `log` to `math.exp`, returning values wrong by ~40x without raising. The existing test asserted the buggy output.
+- [#101](https://github.com/UBC-FRESH/ws3/issues/101) — every `rv=True` path raised `NameError`; PaCal was never imported. Restored via a NumPy 2.0 compatibility shim and a `ws3[rv]` extra.
+- [#97](https://github.com/UBC-FRESH/ws3/issues/97) — `advanced_modeling` imported `ws3.core.compile_scenario`, which does not exist.
+- [#103](https://github.com/UBC-FRESH/ws3/issues/103) — twelve Phase 5 entry points returned fabricated or vacuous results; now gated.
+- 20 unguarded `re.search(...).group(...)` sites in the Woodstock parsers now raise descriptive `ValueError`s.
+
+### Deferred
+- [#98](https://github.com/UBC-FRESH/ws3/issues/98) — remaining 258 mypy findings (annotation coverage). mypy stays `continue-on-error` in CI.
+- [#102](https://github.com/UBC-FRESH/ws3/issues/102) — whether to adopt PaCal as `fresh-pacal`. Gated on licence (GPL-3.0 vs ws3 MIT) and on contacting the upstream authors.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,7 +91,12 @@ warn_unused_configs = true
 disallow_untyped_defs = false
 ignore_missing_imports = true
 strict = true
-warn_unused_ignores = true
+# Disabled deliberately. With ignore_missing_imports = true, an absent optional
+# dependency is typed as Any, which makes every `# type: ignore` on lines touching
+# it look unused. ws3/financial.py alone flips 19 findings depending on whether
+# PaCal happens to be installed, so this check reports differently in CI than
+# locally and cannot be acted on reliably. Revisit as part of #98.
+warn_unused_ignores = false
 warn_redundant_casts = true
 check_untyped_defs = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,19 @@ maintainers = [
 cbm = ["libcbm"]  # pip users can `pip install ws3[cbm]`
 gurobi = ["gurobipy"]
 pulp = ["pulp"]
+# Probabilistic (random variable) financial analysis.
+#
+# PaCal is GPL-3.0-or-later while ws3 is MIT, so it is deliberately an optional
+# extra that the user installs themselves. It is never bundled with ws3.
+#
+# PaCal does not declare its own dependencies, hence sympy and setuptools here.
+# It also predates NumPy 2.0; ws3.financial applies a small compatibility shim
+# for the aliases NumPy removed. See #101 and #102.
+rv = [
+    "pacal>=1.6.1",
+    "sympy",
+    "setuptools",
+]
 docs = [
     "sphinx>=7",
     "sphinx-rtd-theme>=2",

--- a/tests/test_advanced_modeling.py
+++ b/tests/test_advanced_modeling.py
@@ -5,6 +5,7 @@ Tests StochasticOptimizer, MultiObjectiveOptimizer, DynamicPlanner,
 and ClimateScenarioManager classes.
 """
 
+import pytest
 from unittest.mock import MagicMock
 from ws3.advanced_modeling import (
     StochasticOptimizer,
@@ -118,15 +119,20 @@ class TestMultiObjectiveOptimizer:
         assert optimizer.objectives[0]["name"] == "npv"
 
     def test_solve_weighted_sum(self):
-        """Test weighted sum optimization (mocked)."""
-        mock_problem = MagicMock()
-        mock_problem.get_objective_value.return_value = 100.0
-        mock_problem.get_solution.return_value = {"x": [1, 2, 3]}
-        optimizer = MultiObjectiveOptimizer(mock_problem)
+        """
+        Weighted-sum solving is gated (see #103).
+
+        This test previously built a MagicMock whose get_objective_value() and
+        get_solution() returned canned values. Neither method exists on
+        ws3.opt.Problem -- MagicMock supplies any attribute requested, so the
+        test passed against an API that was never written. It also asserted
+        ``result["objective_values"] == {}``, i.e. that the stub's hardcoded
+        empty dict was correct behaviour.
+        """
+        optimizer = MultiObjectiveOptimizer(MagicMock())
         optimizer.add_objective("npv", weight=1.0, direction="maximize")
-        result = optimizer.solve_weighted_sum()
-        assert result["method"] == "weighted_sum"
-        assert result["objective_values"] == {}
+        with pytest.raises(NotImplementedError, match='stub'):
+            optimizer.solve_weighted_sum()
 
 
 class TestDynamicPlanner:
@@ -141,26 +147,16 @@ class TestDynamicPlanner:
         assert planner.plans == []
 
     def test_plan_static(self):
-        """Test static planning (mocked)."""
-        mock_problem = MagicMock()
-        mock_problem.get_objective_value.return_value = 100.0
-        mock_problem.get_solution.return_value = {"x": [1, 2, 3]}
-        planner = DynamicPlanner(mock_problem, n_periods=5)
-        plan = planner.plan_static()
-        assert plan["type"] == "static"
-        assert plan["n_periods"] == 5
-        assert len(planner.plans) == 1
+        """Static planning is gated: it calls Problem methods that do not exist (#103)."""
+        planner = DynamicPlanner(MagicMock(), n_periods=5)
+        with pytest.raises(NotImplementedError, match='stub'):
+            planner.plan_static()
 
     def test_plan_dynamic(self):
-        """Test dynamic planning with re-optimization (mocked)."""
-        mock_problem = MagicMock()
-        mock_problem.get_objective_value.return_value = 100.0
-        mock_problem.get_solution.return_value = {"x": [1, 2, 3]}
-        planner = DynamicPlanner(mock_problem, n_periods=10)
-        plan = planner.plan_dynamic(reoptimize_every=5)
-        assert plan["type"] == "dynamic"
-        assert plan["reoptimize_every"] == 5
-        assert len(plan["plans"]) == 2  # 0 and 5
+        """Dynamic planning is gated for the same reason as plan_static (#103)."""
+        planner = DynamicPlanner(MagicMock(), n_periods=10)
+        with pytest.raises(NotImplementedError, match='stub'):
+            planner.plan_dynamic(reoptimize_every=5)
 
 
 class TestClimateScenarioManager:

--- a/tests/test_experimental_gates.py
+++ b/tests/test_experimental_gates.py
@@ -1,0 +1,129 @@
+"""
+Tests that non-functional Phase 5 code paths refuse to run.
+
+The modules added in Phase 5 (`ws3.advanced_modeling`, `ws3.perf`,
+`ws3.integration`) contain working data structures wrapped around unimplemented
+solve/apply methods. Before gating, several returned confident-looking results
+that could not mean anything -- most notably
+``StochasticOptimizer.solve_stochastic``, which generated random scenarios,
+applied none of them, solved the identical problem N times, and reported a
+variance across N identical values that was always exactly 0.
+
+These tests pin two things:
+
+1. every hollow entry point raises ``NotImplementedError``, so it cannot silently
+   return fabricated output;
+2. the parts that genuinely work are untouched and still work.
+
+See #103.
+"""
+
+import pytest
+
+import ws3.advanced_modeling as am
+import ws3.integration as ig
+import ws3.perf as perf
+
+
+GATED_CALLS = [
+    ('StochasticOptimizer.solve_stochastic',
+     lambda: am.StochasticOptimizer(None).solve_stochastic()),
+    ('StochasticOptimizer._apply_scenario',
+     lambda: am.StochasticOptimizer(None)._apply_scenario(None)),
+    ('MultiObjectiveOptimizer.solve_weighted_sum',
+     lambda: am.MultiObjectiveOptimizer(None).solve_weighted_sum()),
+    ('MultiObjectiveOptimizer.solve_epsilon_constraint',
+     lambda: am.MultiObjectiveOptimizer(None).solve_epsilon_constraint('a', {})),
+    ('MultiObjectiveOptimizer.find_pareto_frontier',
+     lambda: am.MultiObjectiveOptimizer(None).find_pareto_frontier()),
+    ('MultiObjectiveOptimizer._extract_objective_values',
+     lambda: am.MultiObjectiveOptimizer(None)._extract_objective_values()),
+    ('DynamicPlanner.plan_static',
+     lambda: am.DynamicPlanner(None).plan_static()),
+    ('DynamicPlanner.plan_dynamic',
+     lambda: am.DynamicPlanner(None).plan_dynamic()),
+    ('ClimateScenarioManager.apply_climate_effects',
+     lambda: am.ClimateScenarioManager().apply_climate_effects(None, {})),
+    ('ClimateScenarioManager.run_climate_analysis',
+     lambda: am.ClimateScenarioManager().run_climate_analysis(None)),
+    ('IncrementalSolver.solve_with_warmstart',
+     lambda: perf.IncrementalSolver(None).solve_with_warmstart()),
+    ('FHOPSIntegrator.inject_into_model',
+     lambda: ig.FHOPSIntegrator().inject_into_model(None, None, 'x', 1.0)),
+]
+
+
+@pytest.mark.parametrize('name, call', GATED_CALLS, ids=[n for n, _ in GATED_CALLS])
+def test_non_functional_paths_raise(name, call):
+    """Each hollow entry point must raise rather than return fabricated results."""
+    with pytest.raises(NotImplementedError):
+        call()
+
+
+@pytest.mark.parametrize('name, call', GATED_CALLS, ids=[n for n, _ in GATED_CALLS])
+def test_gate_messages_are_actionable(name, call):
+    """The message must say it is a stub and name what is missing."""
+    with pytest.raises(NotImplementedError) as exc:
+        call()
+    msg = str(exc.value)
+    assert 'stub' in msg.lower()
+    assert 'missing' in msg.lower()
+
+
+def test_scenario_generation_still_works():
+    """Scenario generation is real and must remain usable."""
+    opt = am.StochasticOptimizer(None)
+    scenarios = opt.generate_scenarios(
+        n_scenarios=5,
+        uncertainty_type=am.UncertaintyType.GROWTH,
+        mean=1.0,
+        std=0.1,
+    )
+    assert len(scenarios) == 5
+    assert all(isinstance(s, am.StochasticScenario) for s in scenarios)
+
+    summary = opt.get_scenario_summary()
+    assert len(summary) == 5
+
+
+def test_generated_scenarios_actually_vary():
+    """
+    Guards the premise behind the gate.
+
+    The scenario draws were never the problem -- they are genuine random draws.
+    The defect was that they were never applied. If these ever stop varying, the
+    generation side has broken too.
+    """
+    opt = am.StochasticOptimizer(None)
+    scenarios = opt.generate_scenarios(
+        n_scenarios=20,
+        uncertainty_type=am.UncertaintyType.GROWTH,
+        mean=1.0,
+        std=0.2,
+    )
+    factors = {s.parameters['growth_factor'] for s in scenarios}
+    assert len(factors) > 1, 'generated scenarios should not be identical'
+
+
+def test_rcp_scenarios_still_work():
+    """Static RCP scenario data is real and must remain usable."""
+    mgr = am.ClimateScenarioManager()
+    scenarios = mgr.get_rcp_scenarios()
+    assert len(scenarios) == 4
+    assert {s['name'] for s in scenarios} == {'RCP2.6', 'RCP4.5', 'RCP6.0', 'RCP8.5'}
+
+
+def test_add_objective_still_works():
+    """Objective registration is real and must remain usable."""
+    opt = am.MultiObjectiveOptimizer(None)
+    opt.add_objective('volume', weight=0.7)
+    opt.add_objective('carbon', weight=0.3)
+    assert len(opt.objectives) == 2
+
+
+def test_memory_profiler_still_works():
+    """MemoryProfiler uses tracemalloc and genuinely works."""
+    profiler = perf.MemoryProfiler()
+    snapshot = profiler.take_snapshot('test')
+    assert 'current_mb' in snapshot
+    assert isinstance(snapshot['current_mb'], float)

--- a/tests/test_financial.py
+++ b/tests/test_financial.py
@@ -5,7 +5,88 @@ import pytest
 #import fiona
 #import os
 import math
+import ws3.financial
 from ws3.financial import sylv_cred, sylv_cred_formula, piece_size_ratio, harv_cost
+
+
+def test_math_funcs_returns_exp_and_log_not_exp_twice():
+    """
+    Regression test for the log/exp mixup.
+
+    Seven of the eight hand-copied binding pairs in ws3/financial.py bound ``log``
+    to ``math.exp`` rather than ``math.log``, so the deterministic silvicultural
+    credit results were wrong by roughly 40x while raising nothing. The bindings
+    are now produced by a single helper; this pins its contract.
+    """
+    exp, log = ws3.financial._math_funcs(False)
+    assert exp is math.exp
+    assert log is math.log
+    assert exp is not log
+
+
+def test_sylv_cred_f1_matches_independently_computed_value():
+    """
+    Pin _sylv_cred_f1 against the formula evaluated independently.
+
+    Written against the published expression rather than by calling the function
+    and recording whatever it returned, so that it fails if the exp/log mixup is
+    ever reintroduced.
+    """
+    P, vr, vp = 50.0, 0.5, 0.35
+    C1a, C2a = 4.511, -0.628
+    C7d, C8d = -0.391, 1.939
+    C15h, C16h, C17i, C18j = 3.912, -0.0094, 0.0698, 9.2529
+
+    expected = (C1a * vr ** C2a
+                - math.exp(C7d * math.log(vp) + C8d)
+                + C15h * math.exp(C16h * P)
+                - C17i * P
+                + C18j) * P
+
+    assert ws3.financial._sylv_cred_f1(P, vr, vp) == pytest.approx(expected)
+
+
+def test_sylv_cred_f1_rejects_the_buggy_formulation():
+    """The buggy exp-for-log form differs by a wide margin, so the pin is meaningful."""
+    P, vr, vp = 50.0, 0.5, 0.35
+    C1a, C2a = 4.511, -0.628
+    C7d, C8d = -0.391, 1.939
+    C15h, C16h, C17i, C18j = 3.912, -0.0094, 0.0698, 9.2529
+
+    buggy = (C1a * vr ** C2a
+             - math.exp(C7d * math.exp(vp) + C8d)      # exp where log belongs
+             + C15h * math.exp(C16h * P)
+             - C17i * P
+             + C18j) * P
+
+    assert ws3.financial._sylv_cred_f1(P, vr, vp) != pytest.approx(buggy)
+
+
+def test_pacal_guard_raises_informative_error_when_unavailable(monkeypatch):
+    """
+    rv=True must fail with an actionable message, not a bare NameError.
+
+    Previously ``pacal`` was never imported at all (the import sat behind a
+    permanently-true PACAL_BROKEN flag), so every probabilistic path raised
+    ``NameError: name 'pacal' is not defined``.
+    """
+    monkeypatch.setattr(ws3.financial, 'pacal', None)
+    with pytest.raises(NotImplementedError, match='PaCal'):
+        ws3.financial._require_pacal()
+    with pytest.raises(NotImplementedError, match='rv=False'):
+        ws3.financial._math_funcs(True)
+
+
+def test_pacal_available_reports_a_bool():
+    assert isinstance(ws3.financial.pacal_available(), bool)
+
+
+@pytest.mark.skipif(not ws3.financial.pacal_available(),
+                    reason='PaCal not installed (pip install ws3[rv])')
+def test_rv_path_runs_when_pacal_present():
+    """The probabilistic path produces a finite result when PaCal is available."""
+    result = harv_cost(0.35, True, False, rv=True)
+    assert math.isfinite(result)
 
 
 def test_sylv_cred():
@@ -18,7 +99,19 @@ def test_sylv_cred():
     # Call the function
     result = sylv_cred(P, vr, vp, formula)
 
-    expected_result = 126.33
+    # Corrected 2026-07-29. This previously asserted 126.33, which was the output
+    # of the buggy implementation that bound `log` to `math.exp` (see #100). The
+    # test had been written by running the code and recording what it returned, so
+    # it pinned the defect in place rather than catching it.
+    #
+    # Evaluating the published formula independently at P=10, vr=2, vp=1:
+    #
+    #   with math.log (correct):  80.83076   <- current implementation
+    #   with math.exp (as coded): 126.33232  <- former expected value
+    #
+    # The former value matches the buggy form to five decimal places, which is
+    # what confirms the origin of the number.
+    expected_result = 80.83076
 
     # Assertion
     assert result == pytest.approx(expected_result, rel=1.3e-04)

--- a/tests/test_forest.py
+++ b/tests/test_forest.py
@@ -1,7 +1,36 @@
 import sys
 sys.path.append('../ws3/')
 import pytest
-from ws3.forest import Action, DevelopmentType
+from ws3.forest import Action, DevelopmentType, _search
+
+
+def test_search_returns_match_when_pattern_matches():
+    """_search behaves like re.search on the happy path."""
+    m = _search(r'(?<=\().*(?=\))', 'MULTIPLY(a, b)', 'test construct')
+    assert m.group(0) == 'a, b'
+
+
+def test_search_raises_descriptive_error_when_pattern_does_not_match():
+    """
+    Malformed parser input must produce a useful message.
+
+    The Woodstock parsers previously called ``re.search(...).group(...)`` directly.
+    On malformed input the search returns None and the chained ``.group()`` raised
+    ``AttributeError: 'NoneType' object has no attribute 'group'``, naming neither
+    the construct being parsed nor the offending text.
+    """
+    with pytest.raises(ValueError) as exc:
+        _search(r'(?<=\().*(?=\))', 'MULTIPLY no parens here', 'MULTIPLY arguments')
+    msg = str(exc.value)
+    assert 'MULTIPLY arguments' in msg
+    assert 'expected pattern' in msg
+    assert 'MULTIPLY no parens here' in msg
+
+
+def test_search_error_is_not_attribute_error():
+    """Specifically guards against regressing to the old bare AttributeError."""
+    with pytest.raises(ValueError):
+        _search(r'zzz', 'nothing matching', 'some construct')
 
 
 class _StubParent:

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -5,6 +5,7 @@ Tests SolverTuner, MemoryProfiler, PerformanceBenchmark, ResultCache,
 and IncrementalSolver classes.
 """
 
+import pytest
 from unittest.mock import MagicMock, patch
 from ws3.perf import (
     SolverTuner,
@@ -209,24 +210,22 @@ class TestIncrementalSolver:
         assert solver.previous_solution == warm_start
 
     def test_solve_with_warm_start(self):
-        """Test solving with warm start (mocked)."""
-        mock_problem = MagicMock()
-        mock_problem.solve.return_value = None
-        mock_problem.get_solution.return_value = {"x": [1.0, 2.0]}
-        solver = IncrementalSolver(mock_problem)
-        solver.warm_start({"x": [1.0, 2.0]})
+        """
+        Warm-start solving is gated (see #103).
 
-        result = solver.solve_with_warmstart()
-        # Returns False when objective values are equal (0.0 < 0.0 is False)
-        assert result is False
+        Previously mocked Problem.get_solution(), which does not exist -- the real
+        API is Problem.solution().
+        """
+        solver = IncrementalSolver(MagicMock())
+        solver.warm_start({"x": [1.0, 2.0]})
+        with pytest.raises(NotImplementedError, match='stub'):
+            solver.solve_with_warmstart()
 
     def test_solve_without_warm_start(self):
-        """Test solving without warm start returns False."""
-        mock_problem = MagicMock()
-        solver = IncrementalSolver(mock_problem)
-
-        result = solver.solve_with_warmstart()
-        assert result is False
+        """Gated regardless of whether a warm start was supplied (#103)."""
+        solver = IncrementalSolver(MagicMock())
+        with pytest.raises(NotImplementedError, match='stub'):
+            solver.solve_with_warmstart()
 
     def test_get_solution(self):
         """Test getting current solution."""

--- a/ws3/__init__.py
+++ b/ws3/__init__.py
@@ -3,7 +3,7 @@ This is the :py:module::`ws3` Python package.
 .. moduleauthor:: Gregory Paradis gregory.paradis@ubc.ca
 """
 
-__version__ = '1.1.0a3'
+__version__ = '1.1.0a4'
 __all__ = ['common',
            'core',
            'util',

--- a/ws3/advanced_modeling.py
+++ b/ws3/advanced_modeling.py
@@ -1,12 +1,31 @@
 """
 Advanced modeling features for ws3.
 
-This module provides:
-- Stochastic optimization for uncertainty
-- Multi-objective optimization with trade-off analysis
-- Dynamic planning with re-optimization
-- Climate scenario integration
-- Enhanced carbon accounting
+.. warning::
+
+   **Experimental. Not production-ready.**
+
+   This module is a design sketch. Its data structures and scenario generation
+   work, but the methods that apply scenarios and solve are unimplemented stubs.
+
+   Those stubs are gated: they raise :py:exc:`NotImplementedError` rather than
+   returning results. This is deliberate. Before gating,
+   :py:meth:`StochasticOptimizer.solve_stochastic` generated random scenarios,
+   applied none of them, solved the identical problem N times, and reported the
+   variance across N identical values -- always exactly 0. Confident, plausible,
+   and meaningless.
+
+   See #103 for the full audit.
+
+Working today:
+- ``UncertaintyType``, ``StochasticScenario``
+- ``StochasticOptimizer.generate_scenarios`` / ``add_scenario`` / ``get_scenario_summary``
+- ``MultiObjectiveOptimizer.add_objective``
+- ``ClimateScenarioManager.add_scenario`` / ``get_rcp_scenarios``
+
+Gated pending implementation:
+- stochastic, multi-objective, and dynamic solve methods
+- climate effect application and analysis
 """
 
 from __future__ import annotations
@@ -16,6 +35,27 @@ import pandas as pd
 from typing import Any, Dict, List, Optional
 from dataclasses import dataclass, field
 from enum import Enum
+
+
+def _not_production_ready(what: str, missing: str) -> None:
+    """
+    Refuse to run an unimplemented code path.
+
+    Raised instead of returning fabricated or vacuous results. See #103.
+
+    :param what: The method being guarded.
+    :param missing: What is actually absent.
+    """
+    raise NotImplementedError(
+        f"{what} is an experimental stub and is not production-ready.\n"
+        f"\n"
+        f"Missing: {missing}\n"
+        f"\n"
+        f"This code is retained as a design sketch for planned functionality, and "
+        f"is gated so it cannot silently return meaningless results. Tracked in "
+        f"#103. The data structures and scenario generation in this module do work "
+        f"and remain usable."
+    )
 
 
 class UncertaintyType(Enum):
@@ -115,6 +155,13 @@ class StochasticOptimizer:
         :param method: Solution method ('sample_average', 'scenario_reduction', 'robust')
         :return: Solution results
         """
+        _not_production_ready(
+            'StochasticOptimizer.solve_stochastic()',
+            '_apply_scenario() is a no-op, so every scenario solves the identical '
+            'unmodified problem and the reported variance is always 0. It also calls '
+            'Problem.get_objective_value() and Problem.get_solution(), neither of '
+            'which exists (the real API is Problem.z and Problem.solution()).'
+        )
         if not self.scenarios:
             raise ValueError("No scenarios defined")
 
@@ -172,10 +219,12 @@ class StochasticOptimizer:
         return results
 
     def _apply_scenario(self, scenario: StochasticScenario):
-        """Apply scenario parameters to the problem."""
-        # This would modify problem parameters based on scenario
-        # Implementation depends on specific problem structure
-        pass
+        """Apply scenario parameters to the problem. Unimplemented -- see #103."""
+        _not_production_ready(
+            'StochasticOptimizer._apply_scenario()',
+            'a mapping from StochasticScenario parameters onto Problem coefficients. '
+            'Without it, generated scenarios have no effect on the solve.'
+        )
 
     def get_scenario_summary(self) -> pd.DataFrame:
         """Get summary statistics for all scenarios."""
@@ -213,6 +262,12 @@ class MultiObjectiveOptimizer:
         :param weights: Dictionary of objective weights
         :return: Solution results
         """
+        _not_production_ready(
+            'MultiObjectiveOptimizer.solve_weighted_sum()',
+            'the loop that should apply weights to the objective has an empty body, '
+            'so weights are never applied. It also calls Problem.get_solution(), '
+            'which does not exist.'
+        )
         if weights is None:
             weights = {obj['name']: obj['weight'] for obj in self.objectives}
 
@@ -242,6 +297,12 @@ class MultiObjectiveOptimizer:
         :param epsilon_constraints: Constraints on other objectives
         :return: Solution results
         """
+        _not_production_ready(
+            'MultiObjectiveOptimizer.solve_epsilon_constraint()',
+            'the loop that should add epsilon constraints has an empty body, so no '
+            'constraints are added. It also calls Problem.get_solution(), which does '
+            'not exist.'
+        )
         # Add epsilon constraints to problem
         for obj_name, epsilon in epsilon_constraints.items():
             if obj_name != primary_objective:
@@ -266,6 +327,11 @@ class MultiObjectiveOptimizer:
         :param n_points: Number of points on Pareto frontier
         :return: DataFrame with Pareto-optimal solutions
         """
+        _not_production_ready(
+            'MultiObjectiveOptimizer.find_pareto_frontier()',
+            'a working solve_weighted_sum(), which it calls in a loop. Since weights '
+            'are never applied, every point on the frontier would be identical.'
+        )
         pareto_solutions = []
 
         # Generate different weight combinations
@@ -315,10 +381,12 @@ class MultiObjectiveOptimizer:
         return df
 
     def _extract_objective_values(self) -> Dict[str, float]:
-        """Extract objective function values."""
-        # This would extract values from the solved problem
-        # Implementation depends on problem structure
-        return {}
+        """Extract objective function values. Unimplemented -- see #103."""
+        _not_production_ready(
+            'MultiObjectiveOptimizer._extract_objective_values()',
+            'extraction of per-objective values from a solved Problem. It returned a '
+            'hardcoded empty dict, which callers presented as real results.'
+        )
 
 
 class DynamicPlanner:
@@ -339,6 +407,11 @@ class DynamicPlanner:
 
         :return: Static plan
         """
+        _not_production_ready(
+            'DynamicPlanner.plan_static()',
+            'Problem.get_solution() and Problem.get_objective_value(), neither of '
+            'which exists (the real API is Problem.solution() and Problem.z).'
+        )
         self.problem.solve()
 
         plan = {
@@ -358,6 +431,10 @@ class DynamicPlanner:
         :param reoptimize_every: Re-optimize every N periods
         :return: Dynamic plan
         """
+        _not_production_ready(
+            'DynamicPlanner.plan_dynamic()',
+            'the same non-existent Problem methods relied on by plan_static().'
+        )
         plans = []
 
         for period in range(0, self.n_periods, reoptimize_every):
@@ -443,9 +520,13 @@ class ClimateScenarioManager:
         :param scenario: Climate scenario
         :return: Modified ForestModel
         """
-        # This would modify growth curves based on climate scenario
-        # Implementation depends on specific climate-growth relationships
-
+        _not_production_ready(
+            'ClimateScenarioManager.apply_climate_effects()',
+            'a real climate-growth response. It mutates fm.yields in place while '
+            'documenting that it returns a modified copy, and assumes each yield '
+            "entry is a subscriptable mapping with a 'volume' key, which is not the "
+            'ws3 yield structure.'
+        )
         temperature = scenario['temperature_change']
         precipitation = scenario['precipitation_change']
         co2 = scenario['co2_change']
@@ -469,13 +550,19 @@ class ClimateScenarioManager:
         """
         results = []
 
+        _not_production_ready(
+            'ClimateScenarioManager.run_climate_analysis()',
+            'ws3.core.compile_scenario, which does not exist anywhere in the package '
+            '(#97), plus ForestModel.copy() and a working apply_climate_effects(). '
+            'The import is function-local, so "import ws3" still succeeds and the '
+            'breakage only surfaces on first use of this method.'
+        )
+
         for scenario in self.scenarios:
             # Create modified model
             modified_fm = self.apply_climate_effects(fm.copy(), scenario)
 
-            # Compile and solve
-            from ws3.core import compile_scenario
-            problem = compile_scenario(modified_fm, scenario_name=scenario['name'])
+            problem = compile_scenario(modified_fm, scenario_name=scenario['name'])  # noqa: F821
             solution = problem.solve(solver=solver)
 
             results.append({

--- a/ws3/financial.py
+++ b/ws3/financial.py
@@ -31,9 +31,89 @@ from scipy.stats import norm
 #   to
 #     from numpy.fft import fft, ifft
 #
-PACAL_BROKEN = True
-if not PACAL_BROKEN:
-    import pacal
+def _apply_numpy_compat_shim() -> None:
+    """
+    Restore NumPy aliases that PaCal 1.6.1 still uses.
+
+    PaCal was last released 2020-11-07 and predates NumPy 2.0, which removed a
+    number of long-deprecated aliases. PaCal's own code is otherwise fine on
+    modern NumPy, so re-adding the names is enough to make it importable.
+
+    Additive only: nothing is overwritten, each name is restored solely if absent.
+
+    This is a bridge, not a destination. It should be deleted once a maintained
+    fork is available (see #102).
+    """
+    import numpy as _np
+    for _old, _new in (('Inf', 'inf'), ('NaN', 'nan'), ('Infinity', 'inf'),
+                       ('NAN', 'nan'), ('product', 'prod'),
+                       ('cumproduct', 'cumprod'), ('alltrue', 'all'),
+                       ('sometrue', 'any'), ('float_', 'float64'),
+                       ('complex_', 'complex128')):
+        if not hasattr(_np, _old) and hasattr(_np, _new):
+            setattr(_np, _old, getattr(_np, _new))
+    if not hasattr(_np, 'asfarray'):
+        _np.asfarray = lambda a, dtype=_np.float64: _np.asarray(a, dtype=dtype)
+
+
+# Set True to skip the import attempt entirely and force deterministic-only mode.
+PACAL_DISABLED = False
+
+pacal: Any = None
+if not PACAL_DISABLED:
+    try:
+        _apply_numpy_compat_shim()
+        import pacal  # type: ignore[no-redef]
+    except Exception:
+        # Most likely missing PaCal itself, or its undeclared 'sympy' dependency.
+        # Deliberately broad: a partially-importable PaCal is as unusable as an
+        # absent one, and this must never prevent 'import ws3'.
+        pacal = None
+
+
+def pacal_available() -> bool:
+    """True when probabilistic (rv=True) code paths can be used."""
+    return pacal is not None
+
+
+def _require_pacal() -> None:
+    """
+    Guard for code paths that need PaCal.
+
+    Raises a message naming the cause and the way out, instead of letting an
+    unbound name surface as a bare NameError.
+    """
+    if pacal is None:
+        raise NotImplementedError(
+            "This code path requires PaCal for probabilistic (random variable) "
+            "analysis, and PaCal could not be imported.\n"
+            "\n"
+            "Install it with:  pip install ws3[rv]\n"
+            "(PaCal does not declare its dependencies, so 'sympy' is installed "
+            "alongside it.)\n"
+            "\n"
+            "Workaround: pass rv=False for deterministic (point-estimate) results.\n"
+            "\n"
+            "Note: PaCal is GPL-3.0-or-later, whereas ws3 is MIT. It is an optional "
+            "dependency you install yourself and is never bundled with ws3."
+        )
+
+
+def _math_funcs(rv: bool) -> tuple:
+    """
+    Return the (exp, log) pair appropriate to the requested mode.
+
+    Centralized deliberately. These two bindings were previously hand-copied into
+    eight functions, and seven of the copies bound ``log`` to ``math.exp``, so the
+    deterministic silvicultural credit results were wrong by roughly 40x without
+    ever raising (see #100). One definition means that class of defect cannot recur.
+    """
+    if rv:
+        _require_pacal()
+        return pacal.exp, pacal.log
+    return math.exp, math.log
+
+
 #################################################################################################
 
 
@@ -51,8 +131,7 @@ def _sylv_cred_f1(P: float,
                   C18j: float = 9.2529,
                   Kmult: float = 1.,
                   Kplus: float = 0.) -> float:
-    exp = pacal.exp if rv else math.exp
-    log = pacal.log if rv else math.exp
+    exp, log = _math_funcs(rv)
     sc = (C1a*vr**C2a-exp(C7d*log(vp)+C8d)+C15h*exp(C16h*P)-C17i*P+C18j)*P*Kmult+Kplus
     if rv:
         return float(sc.mean())  # type: ignore[union-attr] # expected value, given random variates
@@ -78,8 +157,7 @@ def _sylv_cred_f2(P: float,
                   C18j: float = 7.1029,
                   Kmult: float = 1.,
                   Kplus: float = 0.) -> float:
-    exp = pacal.exp if rv else math.exp  # type: ignore[assignment]
-    log = pacal.log if rv else math.exp  # type: ignore[assignment]
+    exp, log = _math_funcs(rv)
     sc = ((exp(C3b*log(vr)+C4b)-exp(C7d*log(vp)+C8d)+C11f/vr**C12f-C13g/vp**C14g
            +C15h*exp(C16h*P)-C17i*P+C18j)*P*Kmult+Kplus)
     if rv:
@@ -102,8 +180,7 @@ def _sylv_cred_f3(P: float,
                   C18j: float = 7.1029,
                   Kmult: float = 1.,
                   Kplus: float = 0.) -> float:
-    exp = pacal.exp if rv else math.exp  # type: ignore[assignment]
-    log = pacal.log if rv else math.exp  # type: ignore[assignment]
+    exp, log = _math_funcs(rv)
     sc = (exp(C3b*log(vr)+C4b)-exp(C7d*log(vp)+C8d)+C15h*exp(C16h*P)-C17i*P+C18j)*P*Kmult+Kplus
     if rv:
         return float(sc.mean())  # type: ignore[union-attr] # expected value, given random variates
@@ -129,8 +206,7 @@ def _sylv_cred_f4(P: float,
                   C18j: float = 7.1029,
                   Kmult: float = 1.,
                   Kplus: float = 0.) -> float:
-    exp = pacal.exp if rv else math.exp  # type: ignore[assignment]
-    log = pacal.log if rv else math.exp  # type: ignore[assignment]
+    exp, log = _math_funcs(rv)
     sc = ((exp(C3b*log(vr)+C4b)-exp(C7d*log(vp)+C8d)+C11f/vr**C12f-C13g/vp**C14g
            +C15h*exp(C16h*P)-C17i*P+C18j)*P*Kmult+Kplus)
     if rv:
@@ -157,8 +233,7 @@ def _sylv_cred_f5(P: float,
                   C18j: float = 7.1029,
                   Kmult: float = 1.,
                   Kplus: float = 0.) -> float:
-    exp = pacal.exp if rv else math.exp
-    log = pacal.log if rv else math.exp
+    exp, log = _math_funcs(rv)
     sc = ((exp(C3b*log(vr)+C4b)-exp(C7d*log(vp)+C8d)+C11f/vr**C12f-C13g/vp**C14g
            +C15h*exp(C16h*P)-C17i*P+C18j)*P*Kmult+Kplus)
     if rv:
@@ -189,8 +264,7 @@ def _sylv_cred_f6(P: float,
                   C18j: float = 7.1029,
                   Kmult: float = 1.,
                   Kplus: float = 0.) -> float:
-    exp = pacal.exp if rv else math.exp
-    log = pacal.log if rv else math.exp
+    exp, log = _math_funcs(rv)
     sc = (((exp(C3b*log(vr)+C4b)+exp(C5c*log(vr)+C6c)-exp(C7d*log(vp)+C8d)-exp(C9e*log(vp)+C10e))/2
             +C11f/vr**C12f-C13g/vp**C14g+C15h*exp(C16h*P)-C17i*P+C18j*P)*Kmult+Kplus)
     if rv:
@@ -213,8 +287,7 @@ def _sylv_cred_f7(P: float,
                   C18j: float = 7.1029,
                   Kmult: float = 1.,
                   Kplus: float = 0.) -> float:
-    exp = pacal.exp if rv else math.exp  # type: ignore[assignment]
-    log = pacal.log if rv else math.exp  # type: ignore[assignment]
+    exp, log = _math_funcs(rv)
     sc = (exp(C3b*log(vr)+C4b)-exp(C7d*log(vp)+C8d)+C15h*exp(C16h*P)-C17i*P+C18j)*P*Kmult+Kplus
     if rv:
         return float(sc.mean())  # type: ignore[union-attr] # expected value, given random variates
@@ -351,8 +424,7 @@ def harv_cost(piece_size: float,
     _ifc = float(is_finalcut)
     _ith = float(is_toleranthw)
     _pce = float(partialcut_extracare)
-    log = pacal.log if rv else math.log  # type: ignore[assignment]
-    exp = pacal.exp if rv else math.exp  # type: ignore[assignment]
+    exp, log = _math_funcs(rv)
     _exp = A - (B * log(piece_size)) + (C * _pce) + (D * _ifc) - (E * (1 - _ith))
     hc = exp(_exp) + ((F * _ith) + (G * (1 - _ith))) + K
     if rv:

--- a/ws3/financial.py
+++ b/ws3/financial.py
@@ -53,7 +53,7 @@ def _apply_numpy_compat_shim() -> None:
         if not hasattr(_np, _old) and hasattr(_np, _new):
             setattr(_np, _old, getattr(_np, _new))
     if not hasattr(_np, 'asfarray'):
-        _np.asfarray = lambda a, dtype=_np.float64: _np.asarray(a, dtype=dtype)
+        _np.asfarray = lambda a, dtype=_np.float64: _np.asarray(a, dtype=dtype)  # type: ignore[attr-defined]
 
 
 # Set True to skip the import attempt entirely and force deterministic-only mode.

--- a/ws3/forest.py
+++ b/ws3/forest.py
@@ -81,6 +81,33 @@ from ws3.forest_helper import (
 )
 
 
+def _search(pattern: str, string: str, what: str, flags: int = 0) -> 're.Match[str]':
+    """
+    ``re.search`` that fails with a useful message instead of ``None``.
+
+    The Woodstock parsers call ``re.search(...).group(...)`` in many places. When
+    the input is malformed the search returns ``None`` and the chained ``.group()``
+    raises ``AttributeError: 'NoneType' object has no attribute 'group'`` -- which
+    says nothing about which file, which construct, or what was expected.
+
+    :param pattern: Regular expression to apply.
+    :param string: Text to search.
+    :param what: Human-readable description of the construct being parsed, used in
+        the error message.
+    :param flags: Optional ``re`` flags.
+    :return: The match object, guaranteed non-None.
+    :raises ValueError: If the pattern does not match.
+    """
+    match = re.search(pattern, string, flags)
+    if match is None:
+        raise ValueError(
+            f"Could not parse {what}.\n"
+            f"  expected pattern: {pattern}\n"
+            f"  actual input    : {string.strip()!r}"
+        )
+    return match
+
+
 class GreedyAreaSelector:
     """
     Default AreaSelector implementation. Selects areas for treatment from oldest age classes.
@@ -404,7 +431,7 @@ class DevelopmentType:
             return ycomp if ycomp else default_ycomp
 
     def _resolver_multiply(self, yname, d):
-        args = [self._o(s.lower()) for s in re.split(r'\s?,\s?', re.search(r'(?<=\().*(?=\))', d).group(0))]
+        args = [self._o(s.lower()) for s in re.split(r'\s?,\s?', _search(r'(?<=\().*(?=\))', d, f'MULTIPLY arguments for yield {yname!r}').group(0))]
         ##################################################################################################
         # NOTE: Not consistent with Remsoft documentation on 'complex-compound yields' (fix me)...
         ytype_set = set(a.type for a in args if isinstance(a, core.Curve))
@@ -412,36 +439,37 @@ class DevelopmentType:
         ##################################################################################################
 
     def _resolver_divide(self, yname, d):
-        _tmp = list(zip(re.split(r'\s?,\s?', re.search(r'(?<=\().*(?=\))', d).group(0)),
+        _tmp = list(zip(re.split(r'\s?,\s?', _search(r'(?<=\().*(?=\))', d, f'DIVIDE arguments for yield {yname!r}').group(0)),
                    (self._zero_curve, self._unit_curve)))
         args = [self._o(s, default_ycomp) for s, default_ycomp in _tmp]
         return args[0].type if not args[0].is_special else args[1].type, self._rc(args[0] / args[1])
 
     def _resolver_sum(self, yname, d):
-        args = [self._o(s.lower()) for s in re.split(r'\s?,\s?', re.search(r'(?<=\().*(?=\))', d).group(0))]
+        args = [self._o(s.lower()) for s in re.split(r'\s?,\s?', _search(r'(?<=\().*(?=\))', d, f'SUM arguments for yield {yname!r}').group(0))]
         ytype_set = set(a.type for a in args if isinstance(a, core.Curve))
         return ytype_set.pop() if len(ytype_set) == 1 else 'c', self._rc(reduce(lambda x, y: x+y, [a for a in args]))
 
     def _resolver_cai(self, yname, d):
-        arg = self._o(re.split(r'\s?,\s?', re.search(r'(?<=\().*(?=\))', d).group(0))[0])
+        arg = self._o(re.split(r'\s?,\s?', _search(r'(?<=\().*(?=\))', d, f'CAI arguments for yield {yname!r}').group(0))[0])
         return arg.type, self._rc(arg.mai())
 
     def _resolver_mai(self, yname, d):
-        arg = self._o(re.split(r'\s?,\s?', re.search(r'(?<=\().*(?=\))', d).group(0))[0])
+        arg = self._o(re.split(r'\s?,\s?', _search(r'(?<=\().*(?=\))', d, f'MAI arguments for yield {yname!r}').group(0))[0])
         return arg.type, self._rc(arg.mai())
 
     def _resolver_ytp(self, yname, d):
-        arg = self._o(re.search(r'(?<=\().*(?=\))', d).group(0).lower())
+        arg = self._o(_search(r'(?<=\().*(?=\))', d, f'YTP argument for yield {yname!r}').group(0).lower())
         return arg.type, self._rc(arg.ytp())
 
     def _resolver_range(self, yname, d):
-        args = [self._o(s.lower()) for s in re.split(r'\s?,\s?', re.search(r'(?<=\().*(?=\))', d).group(0))]
+        args = [self._o(s.lower()) for s in re.split(r'\s?,\s?', _search(r'(?<=\().*(?=\))', d, f'RANGE arguments for yield {yname!r}').group(0))]
         arg_triplets = [args[i:i+3] for i in range(0, len(args), 3)]
         return args[0].type, self._rc(reduce(lambda x, y: x*y, [t[0].range(t[1], t[2]) for t in arg_triplets]))
 
     def _compile_complex_ycomp(self, yname):
         expression = self._complex_ycomps[yname]
-        keyword = re.search(r'(?<=_)[A-Z]+(?=\()', expression).group(0)
+        keyword = _search(r'(?<=_)[A-Z]+(?=\()', expression,
+                          f'complex yield keyword in {expression.strip()!r}').group(0)
         try:
             ytype, ycomp = self._resolvers[keyword](yname, expression)
             ycomp.label = yname
@@ -532,6 +560,12 @@ class DevelopmentType:
                     raise ValueError('Bad relational operator.')
             else: # must be yname
                 ycomp = self.ycomp(o)
+                if ycomp is None:
+                    raise ValueError(
+                        f"Operability expression for action {acode!r} references yield "
+                        f"component {o!r}, which is not defined for development type "
+                        f"{' '.join(self.key)}."
+                    )
                 if rel_operators[i] == '=':
                     _alo = _ahi = ycomp.lookup(rhs[i])
                 elif rel_operators[i] == '>=':
@@ -758,6 +792,8 @@ class Output:
                 if verbose: print('f is null', f)
                 continue # one of the factors is 0, no point calculating area...
             ages = self._ages if not self._condition else dt.resolve_condition(*self._condition)
+            if ages is None:
+                continue # no ages resolved for this condition, nothing to accumulate
             for age in ages:
                 area = 0.
                 if self._is_invent:
@@ -2127,9 +2163,9 @@ class ForestModel:
                 # pattern matching may not be very robust, but works for now with:
                 # 'FOR XX := 1 to 99'
                 # TO DO: implement DOWNTO, etc.
-                for_var = re.search(r'(?<=FOR\s).+(?=:=)', l).group(0).strip()
-                for_lo = int(re.search(r'(?<=:=).+(?=to)', l).group(0))
-                for_hi = int(re.search(r'(?<=to).+', l).group(0))
+                for_var = _search(r'(?<=FOR\s).+(?=:=)', l, 'FOR loop variable').group(0).strip()
+                for_lo = int(_search(r'(?<=:=).+(?=to)', l, 'FOR loop lower bound').group(0))
+                for_hi = int(_search(r'(?<=to).+', l, 'FOR loop upper bound').group(0))
                 for_buffer = []
                 buffering_for = True
                 continue
@@ -2202,7 +2238,8 @@ class ForestModel:
         """
         with open('%s/%s.%s' % (self.model_path, self.model_name, filename_suffix)) as f:
             data = f.read()
-        _data = re.search(r'\*THEME.*', data, re.M|re.S).group(0) # strip leading junk
+        _data = _search(r'\*THEME.*', data, 'landscape section (no *THEME declaration found)',
+                        re.M | re.S).group(0) # strip leading junk
         t_data = re.split(r'\*THEME.*\n', _data)[1:] # split into theme-wise chunks
         for ti, t in enumerate(t_data, start=ti_offset):
             self._themes.append({})
@@ -2217,7 +2254,7 @@ class ForestModel:
                     defining_aggregates = True
                     continue
                 if not defining_aggregates: # line defines basic theme attribute code
-                    tac = re.search(r'\S+', l.strip()).group(0).lower()
+                    tac = _search(r'\S+', l.strip(), 'theme attribute code').group(0).lower()
                     self._themes[ti][tac] = tac
                     self._theme_basecodes[ti].append(tac)
                 else: # line defines aggregate values (parse out multiple values before comment)
@@ -2520,7 +2557,7 @@ class ForestModel:
         :return str: New theme value string
         """
         if '_TH' in treplace: # assume incrementing integer theme value
-            i = int(re.search(r'(?<=_TH)\w+', treplace).group(0))
+            i = int(_search(r'(?<=_TH)\w+', treplace, '_TH theme index in _REPLACE expression').group(0))
             return eval(re.sub('_TH%i'%i, str(dt.key[i-1]), treplace))
         else:
             assert False # many other possible arguments (see Woodstock documentation for details)
@@ -2654,13 +2691,13 @@ class ForestModel:
                 except Exception:
                     tlock = None
                 try: # _REPLACE keyword (TO DO: implement other cases)
-                    args = re.split(r'\s?,\s?', re.search(r'(?<=_REPLACE\().*(?=\))', l).group(0))
+                    args = re.split(r'\s?,\s?', _search(r'(?<=_REPLACE\().*(?=\))', l, '_REPLACE arguments').group(0))
                     theme_index = int(args[0][3]) - 1
                     treplace = theme_index, args[1]
                 except Exception:
                     treplace = None
                 try: # _APPEND keyword (TO DO: implement other cases)
-                    args = re.split(r'\s?,\s?', re.search(r'(?<=_APPEND\().*(?=\))', l).group(0))
+                    args = re.split(r'\s?,\s?', _search(r'(?<=_APPEND\().*(?=\))', l, '_APPEND arguments').group(0))
                     theme_index = int(args[0][3]) - 1
                     tappend = theme_index, args[1]
                 except Exception:

--- a/ws3/forest.py
+++ b/ws3/forest.py
@@ -2914,10 +2914,10 @@ class ForestModel:
         :return: Dataframe containing CBM SIT age class table
         :rtype: :py:class:`pandas.DataFrame`
         """
-        data = {'name':['age_0'],
-                'class_size':[0],
-                'start_year':[0],
-                'end_year':[0]}
+        data: Dict[str, List[Any]] = {'name': ['age_0'],
+                                      'class_size': [0],
+                                      'start_year': [0],
+                                      'end_year': [0]}
         for i, ac in enumerate(range(self.period_length,
                                      self.max_age+self.period_length,
                                      self.period_length)):

--- a/ws3/integration.py
+++ b/ws3/integration.py
@@ -121,9 +121,17 @@ class FHOPSIntegrator:
         :param species: Species code
         :param site_index: Site index
         """
-        # This would modify the yield curves in the ForestModel
-        # to include cost information from fhops
-        pass
+        raise NotImplementedError(
+            "FHOPSIntegrator.inject_into_model() is an experimental stub and is not "
+            "production-ready.\n"
+            "\n"
+            "Missing: the mapping from fhops cost curves onto ForestModel yield "
+            "curves. The method body was empty, so it silently did nothing while "
+            "appearing to succeed.\n"
+            "\n"
+            "generate_cost_curves() and export_curves() are functional. Tracked in "
+            "#103."
+        )
 
     def export_curves(self, cost_curves: pd.DataFrame,
                      filename: str) -> None:

--- a/ws3/opt.py
+++ b/ws3/opt.py
@@ -72,6 +72,9 @@ class Variable:
         self.lb = lb
         self.ub = ub
         self.val = val
+        # Assigned by the HiGHS backend when the column is added. Declared here
+        # so it is discoverable rather than materializing as a dynamic attribute.
+        self.index: Optional[int] = None
 
 class Constraint:
     """
@@ -126,6 +129,13 @@ class Problem:
             SOLVER_GUROBI: self._solve_gurobi,
             SOLVER_HIGHS: self._solve_highs
         }
+        # Populated by ws3.forest._bld_p_m1 rather than here. Declared so the
+        # attributes are discoverable and type-checkable instead of appearing
+        # only as dynamic assignments from another module.
+        self.trees: Optional[Any] = None
+        self._leaf_ids: Optional[Any] = None
+        self.coeff_funcs: Optional[Any] = None
+        self.formulation: Optional[int] = None
 
     def merge(self, problem: Problem) -> None:
         """

--- a/ws3/perf.py
+++ b/ws3/perf.py
@@ -463,6 +463,17 @@ class IncrementalSolver:
         :param kwargs: Additional solve arguments
         :return: True if solution improved
         """
+        raise NotImplementedError(
+            "IncrementalSolver.solve_with_warmstart() is an experimental stub and is "
+            "not production-ready.\n"
+            "\n"
+            "Missing: it calls Problem.get_solution(), which does not exist. The real "
+            "API is Problem.solution().\n"
+            "\n"
+            "The rest of this module -- MemoryProfiler, ResultCache, "
+            "PerformanceBenchmark and SolverTuner -- is functional and unaffected. "
+            "Tracked in #103."
+        )
         if self.previous_solution is None:
             print("No warm start solution available")
             return False

--- a/ws3/spatial.py
+++ b/ws3/spatial.py
@@ -437,9 +437,8 @@ class ForestRaster:
         import scipy
         _n = 0
         if not aggregate_disturbance:
-            blkid = np.unique(self._x[2][x])
+            blkid = list(np.unique(self._x[2][x]))
             np.random.shuffle(blkid)
-            blkid = list(blkid)
         else:
             disturb_heat = scipy.ndimage.gaussian_filter(
                 ((self._x[1] >= 0) & (self._x[1] <= self._disturb_thresh)).astype(float),


### PR DESCRIPTION
Closes #99
Closes #100
Closes #101
Closes #103

## Phase 7.6 — Defect Sweep (v1.1.0a4)

Fixes the subset of mypy findings that represent **actual defects**, so Phase 8 can
build symbol-validating capabilities on a package that does not reference things
that do not exist.

Deliberately **not** the full 323-error typing debt — that stays in #98.

Parent issue: #99
Branch: `feature/ws3-phase7.6-defect-sweep`

---

## The one that matters most

`ws3/financial.py` bound `log` to `math.exp` in seven of eight places:

```python
exp = pacal.exp if rv else math.exp
log = pacal.log if rv else math.exp     # math.exp, not math.log
```

So `exp(C7d*log(vp)+C8d)` evaluated as `exp(C7d*exp(vp)+C8d)`. Evaluated
independently at `P=10, vr=2, vp=1`:

```
with math.log (correct):  80.83076
with math.exp (as coded): 126.33232
```

**`test_sylv_cred` asserted `126.33`** — the buggy output, to five decimals. It had
been written by running the code and recording the result, so it held the defect in
place instead of catching it. Only `harv_cost` had the binding right, which is what
established the intent.

Unlike every other defect here, this one never raised. It returned confident,
plausible, wrong numbers.

The eight duplicated pairs are now a single `_math_funcs()` helper — the
duplication was the defect's cause.

---

## PaCal restored

Every `rv=True` path raised `NameError: name 'pacal' is not defined`. The import
sat behind a permanently-true `PACAL_BROKEN` flag, so the name was never bound.
Invisible to both checkers: pyflakes treats a guarded import as binding the name,
mypy has `ignore_missing_imports`.

The standing note said to patch `numpy.fft.fftpack` in `pacal/utils.py`. **That
describes PaCal 1.6** — 1.6.1 already imports from `numpy.fft`. The real blockers
were NumPy 2.0 alias removals (`Inf`, `NaN`, `asfarray`, `product`) and an
undeclared `sympy` dependency.

A small additive compatibility shim makes PaCal 1.6.1 work on NumPy 2.5. Verified:

```
pacal_available(): True
harv_cost(0.35, True, False, rv=True) -> 19.391106
```

Available via `pip install ws3[rv]`. **PaCal is GPL-3.0-or-later and ws3 is MIT**,
so it stays an optional dependency the user installs and is never bundled.
Adoption as `fresh-pacal` is a separate decision — #102.

---

## Phase 5 modules gated

Twelve entry points across `advanced_modeling`, `perf`, and `integration` now raise
`NotImplementedError` naming what is missing, instead of returning fabricated
results.

The worst: `StochasticOptimizer.solve_stochastic()` reported `expected_value`,
`variance`, `std_dev` — while `_apply_scenario()` was a bare `pass`. Scenarios were
drawn with real randomness and **never applied**, so the same problem was solved N
times and the variance across N identical values was **always exactly 0**. A user
running uncertainty analysis would read `variance: 0.0` and conclude their model
was robust.

Non-existent APIs these paths called:

| Called | Reality |
|---|---|
| `Problem.get_objective_value()` | real API is `Problem.z` |
| `Problem.get_solution()` | real API is `Problem.solution()` |
| `ForestModel.copy()` | does not exist |
| `ws3.core.compile_scenario` | does not exist (#97) |

**Untouched and still working**: `UncertaintyType`, `StochasticScenario`,
`generate_scenarios`, `get_scenario_summary`, `add_objective`, `get_rcp_scenarios`,
`MemoryProfiler`, `ResultCache`, `PerformanceBenchmark`, `SolverTuner`, pipeline
construction and export.

---

## Parser crash-guards

20 `union-attr` findings, mostly unguarded `re.search(...).group(...)`. On malformed
input `re.search` returns `None` and the chained `.group()` raises

```
AttributeError: 'NoneType' object has no attribute 'group'
```

naming neither the construct nor the offending text. New `forest._search()` raises
`ValueError` identifying the construct, the expected pattern, and the actual input.
Applied to the yield resolvers, complex-yield keyword, `FOR` bounds, `*THEME`
section, theme attribute codes, and `_REPLACE`/`_APPEND` arguments.

Two non-regex cases: `ycomp.lookup()` on a possibly-absent yield component, and
iteration over a possibly-`None` `resolve_condition` result.

---

## Results

| Class | Before | After |
|---|---:|---:|
| `attr-defined` | 12 | 0 |
| `union-attr` | 20 | 0 |
| `unused-ignore` | 34 | 0 |
| mypy total | 323 | 258 |

```
$ python -m pytest
155 passed, 9 skipped

$ flake8 ws3/ tests/
(exit 0)

$ python -m build
Successfully built ws3-1.1.0a4.tar.gz and ws3-1.1.0a4-py3-none-any.whl
```

Test count 123 → 155 from the new gate, regression, and parser-error tests.

`warn_unused_ignores` is disabled: with `ignore_missing_imports`, an absent optional
dependency types as `Any`, so `financial.py` alone flips 19 findings depending on
whether PaCal is installed. The check reported differently in CI than locally and
could not be acted on. Rationale recorded in `pyproject.toml`.

---

## A recurring pattern worth naming

Several existing tests asserted the defective behaviour and had to be rewritten:

```python
mock_problem = MagicMock()
mock_problem.get_objective_value.return_value = 100.0   # method doesn't exist
```

`MagicMock` supplies any attribute requested, so these passed against an API that
was never written. One asserted `result["objective_values"] == {}` — pinning a
stub's hardcoded empty dict as correct. Same shape as `test_sylv_cred` asserting
`126.33`.

**Tests written by running the code and recording what came out cannot catch the
defect they were born from.** Mocks make it worse, because they will fabricate the
missing API too. Three independent instances in this sweep.

---

## Out of scope

- #98 — remaining 258 mypy findings (annotation coverage); mypy stays advisory in CI
- #102 — whether to adopt PaCal as `fresh-pacal`; gated on licence and on contacting
  the upstream authors
- Implementing the gated Phase 5 features properly — its own phase if wanted
