### PR TITLE
Phase 9 — Woodstock format contract and dataset linting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 ### Added
+
+- `ws3.woodstock`: machine-readable contract for the Woodstock input data format (201 keywords)
+  and `lint_dataset`, which reports sections and keywords ws3 does not read. Previously these
+  were ignored silently, so a dataset could import cleanly and produce a model that was not the
+  model that was written.
+
+### Fixed
+
+- `ForestModel.import_landscape_section` now preserves theme descriptions from the `*THEME`
+  declaration instead of discarding them. These are the only statement in a dataset of what a
+  theme position means.
+- `ws3.agent` capabilities now assemble development-type masks at the model's real theme count
+  rather than asking a language model to reproduce it, and `ws3.agent.run` passes the model
+  through to capability construction.
+
+### Added
 - **Agent capabilities** (`ws3.agent`, optional). A small set of operations designed to be driven by an AI coding agent, where the output is validated against real model state before it is returned.
 
   | Capability | Oracle |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `ws3.woodstock`: machine-readable contract for the Woodstock input data format (201 keywords)
+- `ws3.woodstock`: machine-readable contract for the Woodstock input data format (198 keywords)
   and `lint_dataset`, which reports sections and keywords ws3 does not read. Previously these
   were ignored silently, so a dataset could import cleanly and produce a model that was not the
   model that was written.
+- New reference page, *Woodstock Format: What ws3 Reads*, documenting the supported subset and
+  the two deliberate divergences from Woodstock (periods versus years, one-based versus
+  zero-based theme indexing). Its support tables are generated from the contract at docs build
+  time rather than transcribed, so they cannot drift from the importers.
 
 ### Fixed
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -382,14 +382,18 @@ authoritative source for the theme vector.
 | P9.1 Ship the keyword contract as package data | #115 | complete |
 | P9.2 Preserve theme descriptions on LANDSCAPE import | #116 | complete |
 | P9.3 Dataset linter for unsupported sections and keywords | #117 | complete |
-| P9.4 Document the supported subset and divergences | #118 | pending |
+| P9.4 Document the supported subset and divergences | #118 | complete |
 
 Measured support: Landscape, Areas, Yields, Transitions, Outputs, Constants and Schedule are
 implemented; Actions is partial; Optimize, Control, Graphics and Lifespan are stubs that import
-nothing; Regimes, Reports, Queue, Allocation and LpSchedule have no importer. 201 keywords
-catalogued, 27 read by ws3.
+nothing; Regimes, Reports, Queue, Allocation and LpSchedule have no importer. 198 keywords
+catalogued, 25 read by ws3.
 
 Recorded divergences from Woodstock, intentional and not defects:
 
 - Woodstock measures age and action timing in periods; ws3 measures them in years.
 - Woodstock counts themes from one (`_THn`); ws3 stores themes zero-indexed.
+
+Documented at `docs/source/reference/contracts/woodstock_format.rst`. The support tables on
+that page are generated at build time from `ws3.woodstock` by the `docs/source/_ext/ws3_woodstock.py`
+Sphinx extension, so the documented subset cannot drift from the implemented one.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -365,3 +365,31 @@ Work identified during earlier phases and deliberately deferred to keep those ph
 - Issue: [fresh-agent-core#1](https://github.com/UBC-FRESH/fresh-agent-core/issues/1)
 - Status: not_started
 - Scope: 2.0 removed the low-level `Server` decorator API. Main prize is `MCPServer.tool()` generating schemas from type hints, which removes hand-maintained schema drift by construction. Elicitation needs a deliberate decision: it must run before the validate loop, never inside it, or the oracle guarantee weakens into a conversation.
+
+## Phase 9 — Woodstock Format Contract and Dataset Linting
+
+Parent issue: #114
+Branch: `phase9-woodstock-format-contract`
+Status: active
+
+Give ws3 a machine-readable contract for the Woodstock input data format, and use it to report
+what ws3 does and does not read from a dataset. The format is deliberately open ended: a model
+instance declares its own theme set, order and codes, and the LANDSCAPE section is the
+authoritative source for the theme vector.
+
+| Task | Issue | Status |
+| --- | --- | --- |
+| P9.1 Ship the keyword contract as package data | #115 | complete |
+| P9.2 Preserve theme descriptions on LANDSCAPE import | #116 | complete |
+| P9.3 Dataset linter for unsupported sections and keywords | #117 | complete |
+| P9.4 Document the supported subset and divergences | #118 | pending |
+
+Measured support: Landscape, Areas, Yields, Transitions, Outputs, Constants and Schedule are
+implemented; Actions is partial; Optimize, Control, Graphics and Lifespan are stubs that import
+nothing; Regimes, Reports, Queue, Allocation and LpSchedule have no importer. 201 keywords
+catalogued, 27 read by ws3.
+
+Recorded divergences from Woodstock, intentional and not defects:
+
+- Woodstock measures age and action timing in periods; ws3 measures them in years.
+- Woodstock counts themes from one (`_THn`); ws3 stores themes zero-indexed.

--- a/docs/source/_ext/ws3_woodstock.py
+++ b/docs/source/_ext/ws3_woodstock.py
@@ -1,0 +1,145 @@
+"""
+Sphinx directives that generate the Woodstock support tables from the contract.
+
+The point is that the documented subset cannot drift from the implemented one.
+Everything here reads :py:mod:`ws3.woodstock` at build time: the section support
+map, the supported-keyword set, and the shipped keyword contract. Nothing is
+transcribed by hand.
+"""
+
+from __future__ import annotations
+
+from docutils.parsers.rst import Directive
+from docutils.statemachine import StringList
+
+from ws3 import woodstock
+
+#: Rendered in the status column, in the order sections are grouped.
+STATUS_ORDER = ['implemented', 'partial', 'stub', 'none']
+
+STATUS_TEXT = {
+    'implemented': 'implemented',
+    'partial': 'partial',
+    'stub': 'stub — imports nothing',
+    'none': 'no importer',
+}
+
+
+class _Generated(Directive):
+    """A directive whose body is reStructuredText generated at build time."""
+
+    has_content = False
+
+    def lines(self) -> list[str]:  # pragma: no cover - overridden
+        raise NotImplementedError
+
+    def run(self):
+        source = self.state_machine.input_lines.source(
+            self.lineno - self.state_machine.input_offset - 1)
+        node = self.state.parent
+        self.state.nested_parse(
+            StringList(self.lines(), source=source), self.content_offset, node)
+        return []
+
+
+class WoodstockSections(_Generated):
+    """Table of every contract section and what ws3 does with it."""
+
+    def lines(self) -> list[str]:
+        sections = woodstock.sections()
+        rows = []
+        for name in sorted(
+                sections,
+                key=lambda n: (STATUS_ORDER.index(woodstock.section_support(n)[1]), n)):
+            importer, status = woodstock.section_support(name)
+            extension = sections[name].get('file_extension', '')
+            rows.append((
+                name,
+                f'``.{extension}``' if extension else '',
+                f'``{importer}``' if importer else '—',
+                STATUS_TEXT[status],
+            ))
+
+        out = [
+            '.. list-table::',
+            '   :header-rows: 1',
+            '   :widths: 20 12 38 30',
+            '',
+            '   * - Section',
+            '     - File',
+            '     - Importer',
+            '     - Status',
+        ]
+        for row in rows:
+            out.append(f'   * - {row[0]}')
+            out.extend(f'     - {cell}' for cell in row[1:])
+        return out
+
+
+class WoodstockKeywords(_Generated):
+    """Table of the keywords ws3 reads, with the section each belongs to."""
+
+    def lines(self) -> list[str]:
+        known = woodstock.keywords()
+        rows = []
+        for keyword in sorted(woodstock.supported_keywords()):
+            entry = known.get(keyword, {})
+            used_in = ', '.join(entry.get('used_in', [])) or '—'
+            rows.append((f'``{keyword}``', used_in))
+
+        out = [
+            '.. list-table::',
+            '   :header-rows: 1',
+            '   :widths: 25 75',
+            '',
+            '   * - Keyword',
+            '     - Sections it appears in',
+        ]
+        for keyword, used_in in rows:
+            out.append(f'   * - {keyword}')
+            out.append(f'     - {used_in}')
+        return out
+
+
+class WoodstockCoverage(_Generated):
+    """One sentence of measured coverage, counted from the contract."""
+
+    def lines(self) -> list[str]:
+        catalogued = len(woodstock.keywords())
+        supported = len(woodstock.supported_keywords())
+        counts = dict.fromkeys(STATUS_ORDER, 0)
+        for name in woodstock.sections():
+            counts[woodstock.section_support(name)[1]] += 1
+        return [
+            f'The contract catalogues **{catalogued} keywords** across '
+            f'**{len(woodstock.sections())} sections**. ws3 reads '
+            f'**{supported}** of those keywords. Of the sections, '
+            f'{counts["implemented"]} are implemented, {counts["partial"]} is '
+            f'partial, {counts["stub"]} are stubs that import nothing, and '
+            f'{counts["none"]} have no importer at all.',
+        ]
+
+
+class WoodstockDivergences(_Generated):
+    """Definition list of the recorded, deliberate departures from Woodstock."""
+
+    TITLES = {
+        'time_unit': 'Time unit: periods versus years',
+        'theme_indexing': 'Theme indexing: one-based versus zero-based',
+    }
+
+    def lines(self) -> list[str]:
+        out: list[str] = []
+        for key, text in woodstock.DIVERGENCES.items():
+            out.append(self.TITLES.get(key, key))
+            out.append(f'   {text}')
+            out.append('')
+        return out
+
+
+def setup(app):
+    app.add_directive('woodstock-sections', WoodstockSections)
+    app.add_directive('woodstock-keywords', WoodstockKeywords)
+    app.add_directive('woodstock-coverage', WoodstockCoverage)
+    app.add_directive('woodstock-divergences', WoodstockDivergences)
+    return {'version': '1', 'parallel_read_safe': True}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -22,6 +22,7 @@ import sys
 sys.path.insert(0, os.path.abspath('../..'))
 import ws3
 sys.path.insert(0, os.path.abspath('../../ws3'))
+sys.path.insert(0, os.path.abspath('_ext'))
 
 # -- Misc Stuff -----------------------------------------------------------
 intersphinx_mapping = {'http://docs.python.org/3': None}
@@ -57,7 +58,8 @@ extensions = [
     'sphinx.ext.viewcode',
     'sphinxcontrib.mermaid',
     'nbsphinx',
-    'sphinx_rtd_theme']
+    'sphinx_rtd_theme',
+    'ws3_woodstock']
 
 # Skip notebook execution entirely (data files not available in CI)
 nbsphinx_execute = 'never'

--- a/docs/source/reference/contracts/index.rst
+++ b/docs/source/reference/contracts/index.rst
@@ -28,6 +28,7 @@ Contract Pages
    :maxdepth: 1
 
    data_contracts
+   woodstock_format
    runtime_invariants
    module_boundaries
    output_format_spec

--- a/docs/source/reference/contracts/woodstock_format.rst
+++ b/docs/source/reference/contracts/woodstock_format.rst
@@ -1,0 +1,129 @@
+Woodstock Format: What ws3 Reads
+================================
+
+ws3 imports an essential subset of the Woodstock model input data format. The
+boundary of that subset used to be invisible: keywords outside it are not
+rejected, they are *ignored*. A dataset can declare an ``OPTIMIZE`` section, or
+use ``*ACTIONSERIES``, and import without complaint — producing a model that is
+quietly not the model that was written. No error, wrong answer.
+
+This page is generated from the contract shipped with the package
+(:py:mod:`ws3.woodstock`), so it cannot drift from what the importers actually
+do.
+
+.. woodstock-coverage::
+
+The format is open ended by design
+----------------------------------
+
+A Woodstock model instance declares its own themes, in its own order, with its
+own stratification variable codes within each theme. There is no fixed
+allocation of meaning to theme positions, and no theme count that is standard.
+
+The ``LANDSCAPE`` section is the authoritative source for all of it: the
+cardinality and order of the themes in the theme vector, the values each theme
+is allowed to take, the ``*AGGREGATE`` theme values, and the constants. The
+number of themes declared there determines the length of every development-type
+key in the model.
+
+Datasets that look structurally alike usually do so because one author reused
+their own conventions, not because the format imposes anything. Do not infer
+theme semantics from a sample of models.
+
+``*THEME`` declaration lines carry a descriptive name after the keyword, and
+that description is the only statement in a dataset of what a theme position
+means. :py:meth:`ws3.forest.ForestModel.import_landscape_section` preserves it
+as ``__description__`` on each entry of ``ForestModel._themes``; where a dataset
+omits it, ws3 has nothing to go on and says so rather than inventing a meaning.
+The generated theme names (``theme0``, ``theme1``, ...) are positional labels
+and carry no meaning of their own.
+
+Sections
+--------
+
+``stub`` is called out separately from ``no importer`` because the failure mode
+differs in a way that matters. A stub method exists and returns successfully, so
+a caller has every reason to believe the section was read. It was not.
+
+.. woodstock-sections::
+
+Keywords ws3 reads
+------------------
+
+Every other catalogued keyword is ignored on import.
+
+.. woodstock-keywords::
+
+Deliberate divergences from Woodstock
+-------------------------------------
+
+These are recorded in the contract rather than treated as defects.
+
+.. woodstock-divergences::
+
+Linting a dataset
+-----------------
+
+:py:func:`ws3.woodstock.lint_dataset` reports what ws3 will not read from a
+dataset. It reads the section files directly: nothing is imported, no model is
+built, and nothing is modified. It is advisory, and it is not required in order
+to import a model — but running it before you trust an import is cheap.
+
+.. code-block:: python
+
+   from ws3.woodstock import lint_dataset, format_findings
+
+   findings = lint_dataset('examples/data/woodstock_model_files_tsa24_clipped',
+                           'tsa24_clipped')
+   print(format_findings(findings))
+
+Run against the ``tsa24_clipped`` dataset shipped with the examples, that
+reports:
+
+.. code-block:: text
+
+   error: .../tsa24_clipped.lif: the LIFESPAN section is present but not imported:
+     import_lifespan_section is a stub and imports nothing. Everything in this
+     file is ignored.
+   error: .../tsa24_clipped.opt: the OPTIMIZE section is present but not imported:
+     import_optimize_section is a stub and imports nothing. Everything in this
+     file is ignored.
+   error: .../tsa24_clipped.que: the QUEUE section is present but not imported:
+     ws3 has no importer for it. Everything in this file is ignored.
+   error: .../tsa24_clipped.rep: the REPORTS section is present but not imported:
+     ws3 has no importer for it. Everything in this file is ignored.
+   error: .../tsa24_clipped.run: the CONTROL section is present but not imported:
+     import_control_section is a stub and imports nothing. Everything in this
+     file is ignored.
+
+   5 section(s) not imported, 0 keyword(s) ignored.
+
+Five files in that dataset are read by nobody. That is not a defect report — the
+model built from it has carried real work — but it is the difference between
+knowing that and assuming otherwise.
+
+Findings are ordered by severity, then file, then line. Each
+:py:class:`ws3.woodstock.Finding` carries the severity, section, path, line and
+keyword separately, so the report can be rendered any way you like:
+
+.. code-block:: python
+
+   errors = [f for f in findings if f.severity == 'error']
+   for f in errors:
+       print(f.section, f.path)
+
+To check only part of a dataset, pass the section identifiers:
+
+.. code-block:: python
+
+   findings = lint_dataset(path, name, sections_to_check=['Actions', 'Yields'])
+
+An empty result means ws3 imports everything present in that dataset.
+
+API
+---
+
+.. automodule:: ws3.woodstock
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/planning/handoff_github_mcp_setup.md
+++ b/planning/handoff_github_mcp_setup.md
@@ -1,0 +1,146 @@
+# Handoff — GitHub MCP server setup (Windows 11 + VS Code, or Linux + code-server)
+
+Purpose: a reusable, machine-agnostic procedure for giving a VS Code environment working,
+authenticated GitHub MCP tools that do not re-prompt for a token every session. Hand the section
+below the horizontal rule to a coding agent on the target machine.
+
+Provenance: executed and verified end to end on Linux + code-server (jupyterhub04) on 2026-07-31,
+confirmed by live `get_me` and issue-read calls plus process identification. The Windows steps are
+the same design translated to Windows paths and have **not** yet been executed. Treat the Linux
+path as verified and the Windows path as unverified until the agent completes step 5.
+
+Why this exists: the previous setup used `${input:}` with the hosted HTTP endpoint. It re-prompted
+for a PAT every session on headless Linux (no keyring) and was documented as working without
+anyone ever invoking a GitHub tool to check. Both problems are addressed below.
+
+Paste everything below this line into a Copilot Chat agent session on the target machine.
+
+---
+
+Set up the GitHub MCP server in my VS Code environment so that authenticated GitHub tools are
+available in Copilot Chat agent mode, **without re-prompting me for a token every session**.
+
+First, tell me which environment you have detected — Windows 11 + VS Code Desktop, or Linux +
+code-server — and follow the matching column throughout. Do not guess; check the OS and whether
+the editor is code-server.
+
+## Approach
+
+Run the official `github-mcp-server` binary over stdio, with the token supplied from a local file
+via `envFile`. Do not use `${input:...}` and do not use `${env:...}`. Rationale is in the
+constraints section; read it before deviating.
+
+## Step 1 — Install the binary
+
+Get the latest release from https://github.com/github/github-mcp-server/releases
+
+| | Windows 11 | Linux + code-server |
+|---|---|---|
+| Asset | `github-mcp-server_Windows_x86_64.zip` | `github-mcp-server_Linux_x86_64.tar.gz` |
+| Install to | `%LOCALAPPDATA%\github-mcp\github-mcp-server.exe` | `~/.local/bin/github-mcp-server` |
+| Post-install | — | `chmod +x` |
+
+Use the `arm64` asset instead if the machine is ARM. Confirm with `github-mcp-server --version`
+and show me the output. Do not proceed until that prints a version.
+
+Do not substitute `@modelcontextprotocol/server-github` via npx, a Docker image, or a
+`github-mcp-cli` wrapper. If you cannot install the binary, stop and tell me why rather than
+falling back to something else.
+
+## Step 2 — Create the token file
+
+| | Windows 11 | Linux + code-server |
+|---|---|---|
+| Path | `%USERPROFILE%\.config\github-mcp\.env` | `~/.config/github-mcp/.env` |
+| Permissions | `icacls`, remove inheritance, grant only current user | `chmod 700` dir, `chmod 600` file |
+
+Contents, exactly one line:
+
+```
+GITHUB_PERSONAL_ACCESS_TOKEN=<my token>
+```
+
+Create the file with the value **empty** and tell me to paste the token in myself. Do not ask me
+for the token in chat, do not echo it, and do not read the file back to me. If I do not already
+have a PAT, tell me to create one with `repo` scope, plus `read:org` and `read:user` if I want org
+and team queries.
+
+## Step 3 — Write the MCP config
+
+This is a **user-level** config. Do not put it in a workspace `.vscode/mcp.json`.
+
+| Environment | Path |
+|---|---|
+| Windows 11 | `%APPDATA%\Code\User\mcp.json` (`Code - Insiders` if applicable) |
+| Linux + code-server | `~/.local/share/code-server/User/mcp.json` |
+
+On Linux, also check for `~/.vscode-server/data/User/mcp.json` and `~/.config/Code/User/mcp.json`.
+If more than one exists, back each up with a timestamped suffix and write the same content to all
+of them, then confirm they are identical. Divergent copies across these locations are a real
+failure mode and cause confusing behaviour.
+
+Content:
+
+```json
+{
+  "servers": {
+    "github": {
+      "type": "stdio",
+      "command": "<absolute path to the binary from step 1>",
+      "args": ["stdio"],
+      "envFile": "${userHome}/.config/github-mcp/.env"
+    }
+  }
+}
+```
+
+Forward slashes work on Windows. Back up any existing config before overwriting it.
+
+## Step 4 — Start the server
+
+Command palette -> `MCP: List Servers` -> select `github` -> Start/Restart Server.
+
+## Step 5 — Verification (do not skip, do not substitute)
+
+A well-formed config file is **not** evidence that anything works. Neither is the server appearing
+in `MCP: List Servers`. Prove it by invoking tools:
+
+1. Call the GitHub `get_me` tool. Show me the returned `login`.
+2. Call a repository read — for example issue 114 in `UBC-FRESH/ws3` — and show me the title.
+3. Confirm which process is serving the calls:
+   - Linux: `pgrep -af github-mcp-server`
+   - Windows: `Get-Process github-mcp-server | Format-List Path`
+
+   This step matters. A previously configured server can still be alive in the session and answer
+   your calls, making a broken new config look like it works.
+
+If any call fails, report the exact error text and the MCP server log contents. Do not adjust
+config and declare success without re-running all three checks.
+
+Finally, tell me to reload the window and confirm I am **not** prompted for a token. That is the
+whole point of the exercise.
+
+## Constraints — do not "improve" on these
+
+- The top-level key is `servers`, **not** `mcpServers`. `mcpServers` is the Claude Desktop format;
+  VS Code ignores it silently, so the config looks fine and does nothing.
+- Do not use `${input:...}` with `"password": true`. That stores the token in VS Code
+  `SecretStorage`, which needs an OS keyring. On a headless Linux box there is typically no
+  keyring, no libsecret and no session D-Bus, so it falls back to in-memory storage and
+  **re-prompts every session**. `envFile` avoids the issue on both platforms.
+- Do not use `${env:...}`. The VS Code process environment differs from the shell environment,
+  especially under code-server, and it does not resolve reliably.
+- Never commit the `.env` file, print it, or paste its contents anywhere. On Linux, if it is
+  inside a git repo, stop and move it out.
+
+## Troubleshooting notes
+
+- Tool names appear as `mcp_github_mcp_se_*`. The `github-mcp-se` fragment is a **truncation of
+  `github-mcp-server`**, not a configured server name. Do not grep config files for it.
+- `TypeError: Cannot read properties of undefined (reading 'invoke')` on every tool call means a
+  stale tool registration: the tools are registered from an earlier session but no server is
+  running now. Restart the server; do not edit config.
+- To confirm a server genuinely started, look for a per-server MCP log in the session log
+  directory (Linux: `~/.local/share/code-server/logs/<session>/`). A lone `mcpGateway.log`
+  containing only `Initialized` means no server started.
+- `github-mcp-cli` installed in a Python venv is not this server and requires Deno.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ dependencies = [
   "fiona",
   "profilehooks",
   "dill",
-  "highspy"
+  "highspy",
+  "pyyaml>=5.1"
 ]
 maintainers = [
   {name = "Kathleen Coupland", email = "kathleen.coupland@ubc.ca"},

--- a/tests/test_agent_capabilities.py
+++ b/tests/test_agent_capabilities.py
@@ -177,10 +177,190 @@ class TestBuildMaskParsing:
         with pytest.raises(ParseError, match='mask'):
             BuildMask(fm).parse('I think the mask should be ? ? ?')
 
-    def test_rejects_json_without_a_mask_key(self, fm):
+    def test_rejects_json_without_a_recognised_key(self, fm):
         from fresh_agent_core.capability import ParseError
-        with pytest.raises(ParseError, match='mask'):
+        with pytest.raises(ParseError, match='constraints'):
             BuildMask(fm).parse(json.dumps({'answer': 'a b'}))
+
+
+class TestBuildMaskArityIsStructural:
+    """
+    Mask arity comes from the model, never from the language model.
+
+    The theme count is authoritative state read from the LANDSCAPE section, so a
+    capability that asks the model to reproduce it is inventing a failure mode.
+    A live 9B model returned ten entries for this five-theme model, which is what
+    prompted assembling the mask here instead.
+    """
+
+    def _constraints(self, mapping):
+        return json.dumps({'constraints': mapping, 'reasoning': 'because'})
+
+    def test_no_constraints_yields_all_wildcards(self, fm):
+        mask = BuildMask(fm).parse(self._constraints({}))
+        assert mask == tuple(['?'] * fm.nthemes())
+
+    def test_sparse_constraints_are_padded_to_full_arity(self, fm):
+        key = list(fm.dtypes)[0]
+        mask = BuildMask(fm).parse(self._constraints({'1': key[1]}))
+        assert len(mask) == fm.nthemes()
+        assert mask[1] == key[1].lower()
+        assert all(m == '?' for i, m in enumerate(mask) if i != 1)
+
+    def test_arity_holds_for_every_subset_of_constrained_themes(self, fm):
+        """The property that makes the redesign worth it, checked exhaustively."""
+        capability = BuildMask(fm)
+        key = list(fm.dtypes)[0]
+        for size in range(fm.nthemes() + 1):
+            mapping = {str(i): key[i] for i in range(size)}
+            mask = capability.parse(self._constraints(mapping))
+            assert len(mask) == fm.nthemes(), f'arity broke for {size} constraints'
+
+    def test_assembled_mask_always_resolves(self, fm):
+        """Assembly plus the real oracle: a wildcard-padded key must match."""
+        capability = BuildMask(fm)
+        key = list(fm.dtypes)[0]
+        mask = capability.parse(self._constraints({'0': key[0]}))
+        assert capability.validate(mask, fm).ok is True
+
+    def test_out_of_range_position_is_rejected(self, fm):
+        from fresh_agent_core.capability import ParseError
+        with pytest.raises(ParseError, match='out of range'):
+            BuildMask(fm).parse(self._constraints({str(fm.nthemes()): 'x'}))
+
+    def test_non_integer_position_is_rejected(self, fm):
+        from fresh_agent_core.capability import ParseError
+        with pytest.raises(ParseError, match='not a position number'):
+            BuildMask(fm).parse(self._constraints({'not_a_theme': 'x'}))
+
+    def test_theme_name_is_accepted_as_a_position(self, fm):
+        """
+        A live model keys constraints by the theme name it was shown.
+
+        The name identifies the theme unambiguously, so resolving it is
+        deterministic. Rejecting it burned retries and, worse, pushed the model
+        into declaring a perfectly groundable request ungroundable.
+        """
+        key = list(fm.dtypes)[0]
+        name = fm._themes[1]['__name__']
+        mask = BuildMask(fm).parse(self._constraints({name: key[1]}))
+        assert len(mask) == fm.nthemes()
+        assert mask[1] == key[1].lower()
+
+    def test_theme_name_matching_is_case_insensitive(self, fm):
+        key = list(fm.dtypes)[0]
+        name = fm._themes[1]['__name__'].upper()
+        assert BuildMask(fm).parse(self._constraints({name: key[1]}))[1] == key[1].lower()
+
+    def test_constraints_must_be_an_object(self, fm):
+        from fresh_agent_core.capability import ParseError
+        with pytest.raises(ParseError, match='must be a mapping'):
+            BuildMask(fm).parse(json.dumps({'constraints': ['a', 'b']}))
+
+    def test_prompt_does_not_ask_the_model_to_assemble_the_mask(self, fm):
+        from ws3.agent.capabilities.build_mask import MaskRequest
+        prompt = BuildMask(fm).build_messages(MaskRequest('everything'), ())[0]['content']
+        assert 'Do not assemble the mask yourself' in prompt
+        assert str(fm.nthemes()) in prompt
+
+
+class TestBuildMaskAggregates:
+    """
+    Aggregates are valid mask values and carry the modeller's own semantics.
+
+    ``unmask`` expands them via ``_expand_theme``, so treating one as an unknown
+    code would reject a better answer than the model could otherwise give.
+    """
+
+    @pytest.fixture
+    def fm_agg(self):
+        from ws3.forest import ForestModel
+
+        model = ForestModel(
+            model_name='agg', model_path='.', base_year=2020,
+            horizon=1, period_length=10, max_age=100,
+        )
+        model.add_theme('species', basecodes=['sw', 'pl', 'aw'],
+                        aggs={'conifer': ['sw', 'pl']})
+        model.add_theme('site', basecodes=['good', 'poor'])
+        return model
+
+    def test_prompt_lists_aggregates_separately_from_basecodes(self, fm_agg):
+        from ws3.agent.themes import ThemeSchema
+        summary = ThemeSchema.from_model(fm_agg).describe()
+        assert 'aggregate conifer: sw, pl' in summary
+        # The aggregate must not be muddled in with the basecode listing.
+        codes_line = next(l for l in summary.splitlines() if l.strip().startswith('codes:'))
+        assert 'conifer' not in codes_line
+
+    def test_aggregate_is_accepted_as_a_code(self, fm_agg):
+        capability = BuildMask(fm_agg)
+        mask = capability.parse(
+            json.dumps({'constraints': {'0': 'conifer'}, 'reasoning': 'x'})
+        )
+        assert mask == ('conifer', '?')
+        # No dtypes are loaded, so this cannot resolve -- but the failure must be
+        # "matched nothing", not "conifer is not a code for this theme".
+        assert not any(
+            'not a code' in e for e in capability.validate(mask, fm_agg).errors
+        )
+
+    def test_unknown_code_feedback_offers_the_aggregate(self, fm_agg):
+        verdict = BuildMask(fm_agg).validate(('softwood', '?'), fm_agg)
+        assert verdict.ok is False
+        assert any('conifer' in e for e in verdict.errors)
+
+
+class TestRunSuppliesModelAtConstruction:
+    """
+    ``ws3.agent.run`` must build the capability *with* the model.
+
+    Every other test here constructs ``BuildMask(fm)`` by hand, so none of them
+    exercised the real entry point -- which built a model-blind capability and
+    could not assemble a mask at all. Caught only by a live call; kept as a
+    regression test because the offline suite was structurally blind to it.
+    """
+
+    def test_run_can_assemble_a_mask(self, fm):
+        raw = json.dumps({'constraints': {}, 'reasoning': 'everything'})
+        result = ws3.agent.run(
+            'build_mask', 'all stands',
+            context=fm, provider=FakeProvider([raw], repeat_last=True),
+        )
+        assert result.ok is True, result.errors
+        assert result.value == tuple(['?'] * fm.nthemes())
+
+    def test_get_passes_the_model_through(self, fm):
+        from ws3.agent.capabilities.build_mask import MaskRequest
+        capability = ws3.agent.get('build_mask', fm)
+        prompt = capability.build_messages(MaskRequest('x'), ())[0]['content']
+        assert f'has {fm.nthemes()} themes' in prompt
+
+    def test_non_model_context_is_not_mistaken_for_a_model(self, fm):
+        """
+        Other capabilities take other context, which must not reach BuildMask.
+
+        The guard sits in ``run``, where ``context`` is deliberately untyped;
+        ``get`` takes an explicit model by contract.
+        """
+        from ws3.agent import _as_forest_model
+        assert _as_forest_model(fm) is fm
+        assert _as_forest_model(None) is None
+        assert _as_forest_model(ImportFailure(
+            model_path='p', model_name='n', section='lan', error='e',
+        )) is None
+
+    def test_run_tolerates_a_non_model_context(self):
+        """Constructing the registry must not explode on unrelated context."""
+        raw = json.dumps({
+            'cause': 'something went wrong', 'next_actions': ['check the file'],
+            'symbols_referenced': [],
+        })
+        result = ws3.agent.run(
+            'explain_exception', ValueError('boom'),
+            context=None, provider=FakeProvider([raw], repeat_last=True),
+        )
+        assert result.ok is True, result.errors
 
 
 class TestBuildMaskEndToEnd:

--- a/tests/test_forest.py
+++ b/tests/test_forest.py
@@ -1,7 +1,58 @@
 import sys
 sys.path.append('../ws3/')
+import textwrap
+from pathlib import Path
+
 import pytest
-from ws3.forest import Action, DevelopmentType, _search
+from ws3.forest import Action, DevelopmentType, ForestModel, _search
+
+
+class TestLandscapeThemeDescriptions:
+    """
+    Theme descriptions must survive import.
+
+    Theme order and meaning are entirely user-defined in the Woodstock format, so
+    the text trailing a ``*THEME`` declaration is the only thing in the dataset
+    that states what a theme position represents. The importer used to discard it,
+    which left every theme anonymous downstream.
+    """
+
+    @pytest.fixture
+    def model(self, tmp_path: Path) -> ForestModel:
+        (tmp_path / 'm.lan').write_text(textwrap.dedent("""\
+            *THEME Timber Supply Area (TSA)
+            tsa24
+            *THEME Leading tree species
+            sw
+            pl
+            *AGGREGATE conifer
+            sw pl
+            *THEME
+            1
+            2
+            """))
+        fm = ForestModel(model_name='m', model_path=str(tmp_path),
+                         base_year=2020, horizon=1, period_length=10, max_age=100)
+        fm.import_landscape_section()
+        return fm
+
+    def test_descriptions_are_extracted(self, model):
+        assert model._themes[0]['__description__'] == 'Timber Supply Area (TSA)'
+        assert model._themes[1]['__description__'] == 'Leading tree species'
+
+    def test_undescribed_theme_yields_empty_description(self, model):
+        """Absent is absent -- it must not be filled in with the placeholder name."""
+        assert model._themes[2]['__description__'] == ''
+
+    def test_theme_count_and_codes_are_unaffected(self, model):
+        assert model.nthemes() == 3
+        assert model.theme_basecodes(0) == ['tsa24']
+        assert model.theme_basecodes(1) == ['sw', 'pl']
+        assert model.theme_basecodes(2) == ['1', '2']
+
+    def test_aggregates_still_parse(self, model):
+        """The declaration line now feeds a capture group; aggregates must survive."""
+        assert model._themes[1]['conifer'] == ['sw', 'pl']
 
 
 def test_search_returns_match_when_pattern_matches():

--- a/tests/test_woodstock.py
+++ b/tests/test_woodstock.py
@@ -1,0 +1,172 @@
+"""
+Tests for the Woodstock format contract and the dataset linter.
+
+The point of the linter is that ws3 reads a subset of the Woodstock format and
+ignores the rest *silently*. A dataset can declare an OPTIMIZE section, import
+without error, and produce a model that is not the model that was written. These
+tests check that the linter says so, and -- just as importantly -- that it does
+not cry wolf about keywords ws3 handles perfectly well.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ws3 import woodstock
+
+MODEL_DIR = (Path(__file__).parent.parent / 'examples' / 'data'
+             / 'woodstock_model_files_tsa24_clipped')
+MODEL_NAME = 'tsa24_clipped'
+
+
+class TestContract:
+    def test_contract_loads(self):
+        assert woodstock.contract()['keywords']
+
+    def test_contract_ships_with_the_package(self):
+        assert woodstock.CONTRACT_PATH.is_file()
+
+    def test_contract_carries_no_vendor_prose(self):
+        """
+        The contract is interface facts only.
+
+        The source documentation is vendor copyright; reproducing its prose in
+        this repository would be a licensing problem, so the generator emits
+        syntax skeletons and argument names and nothing else.
+        """
+        text = woodstock.CONTRACT_PATH.read_text()
+        assert 'REMSOFT' not in text.upper()
+        assert 'COPYRIGHT' not in text.upper()
+
+    def test_every_section_declares_a_file_extension(self):
+        for name, spec in woodstock.sections().items():
+            assert spec.get('file_extension'), f'{name} has no file extension'
+
+    def test_keywords_are_scoped_to_sections(self):
+        """Most keywords say which section they belong to; some are global."""
+        scoped = [k for k, v in woodstock.keywords().items() if v.get('used_in')]
+        assert len(scoped) > 150
+
+
+class TestSupportDeclarations:
+    """
+    ws3's support declarations must stay in step with ws3.
+
+    They are hand-maintained because token searching does not work -- the outputs
+    importer recognises _AREA and _INVENT through a generic prefix check. What
+    *can* be checked mechanically is checked here.
+    """
+
+    def test_every_supported_section_names_a_real_importer(self):
+        from ws3.forest import ForestModel
+        for name, (importer, status) in woodstock.SECTION_SUPPORT.items():
+            if importer is None:
+                assert status == 'none', f'{name} has no importer but status {status}'
+                continue
+            assert hasattr(ForestModel, importer), f'{name}: no {importer}'
+
+    def test_sections_with_an_importer_are_not_marked_absent(self):
+        for name, (importer, status) in woodstock.SECTION_SUPPORT.items():
+            if importer is not None:
+                assert status != 'none', f'{name} has {importer} but is marked none'
+
+    def test_every_section_in_the_contract_has_a_support_declaration(self):
+        missing = set(woodstock.sections()) - set(woodstock.SECTION_SUPPORT)
+        assert not missing, f'no ws3 support declared for: {sorted(missing)}'
+
+    def test_supported_keywords_are_real_woodstock_keywords(self):
+        """A typo here would silently suppress a finding forever."""
+        known = set(woodstock.keywords())
+        unknown = {k for k in woodstock.SUPPORTED_KEYWORDS if k not in known}
+        assert not unknown, f'not in the contract: {sorted(unknown)}'
+
+    def test_divergences_are_recorded(self):
+        assert 'time_unit' in woodstock.DIVERGENCES
+        assert 'periods' in woodstock.DIVERGENCES['time_unit']
+        assert 'years' in woodstock.DIVERGENCES['time_unit']
+
+
+@pytest.mark.skipif(not MODEL_DIR.is_dir(), reason='example model not available')
+class TestLintRealDataset:
+    @pytest.fixture(scope='class')
+    def findings(self):
+        return woodstock.lint_dataset(str(MODEL_DIR), MODEL_NAME)
+
+    def test_reports_the_unread_optimize_section(self, findings):
+        """
+        The case that motivates the linter.
+
+        import_optimize_section is a stub: calling it succeeds and imports
+        nothing, so nothing else in ws3 will ever tell the user.
+        """
+        opt = [f for f in findings if f.section == 'Optimize']
+        assert opt, 'OPTIMIZE section present but not reported'
+        assert opt[0].severity == 'error'
+        assert 'stub' in opt[0].message
+
+    def test_reports_sections_with_no_importer_at_all(self, findings):
+        reported = {f.section for f in findings if f.severity == 'error'}
+        assert {'Queue', 'Reports'} <= reported
+
+    def test_does_not_report_sections_ws3_reads(self, findings):
+        """Landscape, Areas, Yields and Transitions all import correctly."""
+        reported = {f.section for f in findings}
+        assert not reported & {'Landscape', 'Areas', 'Yields', 'Transitions'}
+
+    def test_no_false_positives_on_supported_keywords(self, findings):
+        """
+        Regression test.
+
+        A hand-written support list initially omitted _AREA and _INVENT, which
+        the outputs importer handles through a generic prefix check, so the
+        linter reported two working keywords as ignored. A linter that cries
+        wolf gets switched off.
+        """
+        flagged = {f.keyword for f in findings if f.keyword}
+        assert not flagged & woodstock.SUPPORTED_KEYWORDS
+
+    def test_findings_are_ordered_errors_first(self, findings):
+        severities = [f.severity for f in findings]
+        assert severities == sorted(severities, key=lambda s: {'error': 0, 'warning': 1}.get(s, 2))
+
+    def test_findings_render_with_location(self, findings):
+        assert all(MODEL_NAME in str(f) for f in findings)
+
+
+class TestLintEdgeCases:
+    def test_missing_dataset_yields_no_findings(self, tmp_path):
+        """Absent files are not findings; there is nothing to be wrong about."""
+        assert woodstock.lint_dataset(str(tmp_path), 'nothing_here') == []
+
+    def test_unread_section_is_reported_even_when_trivial(self, tmp_path):
+        (tmp_path / 'm.opt').write_text('; just a comment\n')
+        findings = woodstock.lint_dataset(str(tmp_path), 'm')
+        assert [f.section for f in findings] == ['Optimize']
+
+    def test_comments_are_not_scanned_for_keywords(self, tmp_path):
+        """A keyword named in a comment is prose, not a declaration."""
+        (tmp_path / 'm.yld').write_text('; this model would use *YT if ws3 read it\n')
+        assert woodstock.lint_dataset(str(tmp_path), 'm') == []
+
+    def test_unsupported_keyword_in_a_read_section_is_reported(self, tmp_path):
+        (tmp_path / 'm.are').write_text('*AA ? ? 0 100 aacode\n')
+        findings = woodstock.lint_dataset(str(tmp_path), 'm')
+        assert any(f.keyword == '*AA' for f in findings)
+        assert all(f.line == 1 for f in findings)
+
+    def test_each_unsupported_keyword_is_reported_once(self, tmp_path):
+        (tmp_path / 'm.are').write_text('*AA a\n*AA b\n*AA c\n')
+        findings = [f for f in woodstock.lint_dataset(str(tmp_path), 'm')
+                    if f.keyword == '*AA']
+        assert len(findings) == 1
+
+    def test_restricting_sections(self, tmp_path):
+        (tmp_path / 'm.opt').write_text('_MAXIMIZE x\n')
+        (tmp_path / 'm.que').write_text('*SELECT harvest\n')
+        only = woodstock.lint_dataset(str(tmp_path), 'm', sections_to_check=['Queue'])
+        assert {f.section for f in only} == {'Queue'}
+
+    def test_format_findings_is_explicit_when_clean(self):
+        assert 'No findings' in woodstock.format_findings([])

--- a/ws3/agent/__init__.py
+++ b/ws3/agent/__init__.py
@@ -80,16 +80,21 @@ def _require_core() -> Any:
     return _core
 
 
-def registry() -> Any:
+def registry(fm: Any = None) -> Any:
     """
     The ws3 capability registry.
 
     Built lazily so that importing this module does not construct capabilities
     that may never be used.
+
+    :param fm: Optional :py:class:`~ws3.forest.ForestModel`. Some capabilities
+        need model state at *construction* time, not just at validation time --
+        :py:class:`~ws3.agent.capabilities.build_mask.BuildMask` reads the theme
+        count in order to assemble masks at the right arity.
     """
     _require_core()
     from ws3.agent.capabilities import build_registry
-    return build_registry()
+    return build_registry(fm)
 
 
 def available() -> bool:
@@ -116,14 +121,28 @@ def list_capabilities() -> list[dict[str, str]]:
     return list(registry().describe())
 
 
-def get(name: str) -> Any:
+def _as_forest_model(context: Any) -> Any:
+    """
+    Return *context* if it looks like a :py:class:`~ws3.forest.ForestModel`.
+
+    Duck-typed rather than isinstance-checked so that importing :py:mod:`ws3.agent`
+    does not drag in :py:mod:`ws3.forest`. Capabilities take other kinds of
+    context, so this filters rather than assumes.
+    """
+    return context if hasattr(context, 'nthemes') and hasattr(context, '_themes') else None
+
+
+def get(name: str, fm: Any = None) -> Any:
     """
     Look up a capability by name.
 
+    :param name: Capability name.
+    :param fm: Optional model, passed to capabilities that need it at
+        construction time.
     :raises KeyError: With the available names, since this is usually reached by
         an agent that guessed.
     """
-    return registry().get(name)
+    return registry(fm).get(name)
 
 
 def run(
@@ -155,7 +174,10 @@ def run(
         provider was supplied.
     """
     core = _require_core()
-    capability = get(name)
+    # Some capabilities need model state to build their prompt and to interpret
+    # the response, not merely to validate it, so the context has to reach
+    # construction as well as validation.
+    capability = get(name, _as_forest_model(context))
 
     resolved = config if config is not None else core.config.resolve()
     if resolved is None:

--- a/ws3/agent/capabilities/build_mask.py
+++ b/ws3/agent/capabilities/build_mask.py
@@ -5,6 +5,30 @@ Oracle: :py:meth:`ws3.forest.ForestModel.unmask` resolves the proposed mask
 against the actual model. A mask matching zero development types is rejected --
 it is syntactically fine and operationally useless, which is exactly the failure
 mode a human hits and cannot easily diagnose.
+
+Mask arity is *not* the model's problem. The number of themes is authoritative
+model state, read from the LANDSCAPE section of the input dataset (or from
+whatever built the model), so the language model is asked only which themes to
+constrain and to what code. The full-arity mask is assembled here, in code, with
+every unmentioned position filled in as a wildcard.
+
+This is deliberate. An earlier version asked for the whole space-separated mask
+and let the validator police the length; a live 9B model duly returned ten
+entries for a five-theme model, and the retry cost about 28 seconds to recover a
+fact the code already knew. Do not ask a model to reproduce state you can read.
+
+Know what the oracle does *not* prove. Theme positions carry no fixed meaning:
+the Woodstock format lets each model define its own themes and its own codes
+within them, so nothing about position 2 is knowable from the format. Similar
+layouts across a family of models are a convention of whoever built them, not a
+property of ws3. ``unmask`` therefore establishes that a mask *resolves to real
+development types*, and nothing whatsoever about whether it means what the user
+asked for. A mask that quietly selects the wrong stratum passes this oracle.
+
+The prompt is written accordingly: it presents only what the model instance
+actually declares, forbids assuming a position holds any particular kind of
+information, and offers an explicit way to report that a request cannot be
+grounded -- because guessing produces output the validator will happily accept.
 """
 
 from __future__ import annotations
@@ -15,9 +39,7 @@ from typing import Any, Optional
 
 from fresh_agent_core.capability import Capability, ParseError, Verdict
 
-#: Cap on theme codes listed per theme in the prompt. Real models can carry
-#: hundreds; listing all of them buries the task and wastes context.
-MAX_CODES_PER_THEME = 40
+from ws3.agent.themes import ThemeError, ThemeSchema, schema_for
 
 
 @dataclass(frozen=True)
@@ -30,24 +52,6 @@ class MaskRequest:
     """
 
     description: str
-
-
-def _theme_summary(fm: Any) -> str:
-    """
-    Describe the model's themes so the model can only propose real codes.
-
-    Without this the model invents plausible-looking theme codes, which the
-    validator then rejects -- correct but wasteful. Showing the actual codes turns
-    most of the task into selection rather than generation.
-    """
-    lines = []
-    for index, theme in enumerate(fm._themes):
-        name = theme.get('__name__', f'theme{index}')
-        codes = [k for k in theme if not k.startswith('__')]
-        shown = sorted(codes)[:MAX_CODES_PER_THEME]
-        suffix = '' if len(codes) <= MAX_CODES_PER_THEME else f' ... ({len(codes)} total)'
-        lines.append(f'  position {index} ({name}): {", ".join(shown)}{suffix}')
-    return '\n'.join(lines)
 
 
 class BuildMask(Capability[tuple]):
@@ -78,38 +82,91 @@ class BuildMask(Capability[tuple]):
         """Build a :py:class:`MaskRequest` from MCP tool arguments."""
         return MaskRequest(description=str(payload.get('description', '')))
 
+    def coerce_input(self, inputs: Any) -> MaskRequest:
+        """
+        Accept a bare description string as well as a :py:class:`MaskRequest`.
+
+        The single-string form is the documented convenience call
+        (``ws3.agent.run('build_mask', 'mature spruce stands', context=fm)``), so
+        it has to actually work.
+        """
+        if isinstance(inputs, MaskRequest):
+            return inputs
+        if isinstance(inputs, str):
+            return MaskRequest(description=inputs)
+        if isinstance(inputs, dict):
+            return self.from_payload(inputs)
+        raise TypeError(
+            f'build_mask takes a description string, a dict, or a MaskRequest; '
+            f'got {type(inputs).__name__}'
+        )
+
     def render(self, value: tuple) -> str:
         """Render as a Woodstock-style space-separated mask, ready to paste."""
         return ' '.join(value)
 
     def build_messages(self, inputs: MaskRequest, failures: tuple[str, ...]) -> list[dict[str, str]]:
-        """Build the prompt, folding in why previous attempts were rejected."""
+        """
+        Build the prompt, folding in why previous attempts were rejected.
+
+        Asks for theme constraints rather than a finished mask, so the model never
+        has to count theme positions and cannot get the arity wrong.
+        """
+        count = 'an unknown number of' if self._schema is None else str(self._schema.nthemes)
+        listing = '  (not available)' if self._schema is None else self._schema.describe()
         content = (
-            'You are constructing a development-type mask for a ws3 forest model.\n'
+            'You are selecting development types in a ws3 forest model.\n'
             '\n'
-            'A mask is a space-separated list of theme codes, one per theme position, '
-            'in order. Use ? as a wildcard for any position that should not be '
-            'constrained.\n'
+            'Theme positions have no fixed meaning. This is a Woodstock-format '
+            'model: how many themes there are, what each one represents, and which '
+            'codes it admits are all chosen by whoever built this particular model. '
+            'Do not assume a position holds species, age, site quality, ownership, '
+            'or any other attribute. Other models you have seen tell you nothing '
+            'about this one.\n'
             '\n'
-            f'This model has {self._nthemes} themes. Available codes:\n'
-            f'{self._themes}\n'
+            f'This model has {count} themes. Available codes:\n'
+            f'{listing}\n'
             '\n'
             f'Requested selection: {inputs.description}\n'
             '\n'
+            'List only the theme positions you want to constrain, and the code to '
+            'constrain each one to. Every position you do not mention is left '
+            'unconstrained, matching anything. Do not assemble the mask yourself and '
+            'do not pad it with wildcards -- that is done for you.\n'
+            '\n'
+            'Use only codes listed above. Where an aggregate expresses the request, '
+            'prefer it: aggregates are groupings the modeller defined, so they carry '
+            'the intended meaning.\n'
+            '\n'
             'Respond with a JSON object and nothing else:\n'
-            '  {"mask": "<code-or-? for each theme, space separated>", '
+            '  {"constraints": {"<theme position>": "<code>"}, '
             '"reasoning": "<one sentence>"}\n'
+            '\n'
+            'To select everything, constrain nothing: '
+            '{"constraints": {}, "reasoning": "..."}\n'
+            '\n'
+            'If the request cannot be grounded in the themes and codes listed above, '
+            'say so instead of guessing -- a wrong mask resolves perfectly well and '
+            'will not be caught:\n'
+            '  {"insufficient_information": "<what is missing>"}\n'
         )
         if failures:
             content += (
                 '\nPrevious attempts were rejected:\n'
                 + '\n'.join(f'  - {f}' for f in failures)
-                + '\nPropose a different mask that avoids these problems.\n'
+                + '\nPropose different constraints that avoid these problems.\n'
             )
         return [{'role': 'user', 'content': content}]
 
     def parse(self, raw: str) -> tuple:
-        """Extract the mask as a tuple of theme codes."""
+        """
+        Build the mask from the model's theme constraints.
+
+        Accepts a finished ``mask`` too, since a model that volunteers one is not
+        worth a retry -- but that path is checked for arity by
+        :py:meth:`validate`, whereas the ``constraints`` path cannot get arity
+        wrong by construction.
+        """
         text = raw.strip()
         # Models frequently wrap JSON in a fenced code block despite instructions.
         # Tolerating that is cheaper than burning a retry on formatting.
@@ -121,18 +178,44 @@ class BuildMask(Capability[tuple]):
             payload = json.loads(text)
         except json.JSONDecodeError as exc:
             raise ParseError(
-                f'expected a JSON object with a "mask" key, got: {raw[:200]!r} ({exc})'
+                f'expected a JSON object with a "constraints" key, got: '
+                f'{raw[:200]!r} ({exc})'
             ) from exc
 
-        if not isinstance(payload, dict) or 'mask' not in payload:
-            raise ParseError('expected a JSON object containing a "mask" key')
+        if not isinstance(payload, dict):
+            raise ParseError('expected a JSON object')
 
-        mask = payload['mask']
-        if isinstance(mask, str):
-            return tuple(mask.lower().split())
-        if isinstance(mask, list):
-            return tuple(str(m).lower() for m in mask)
-        raise ParseError(f'"mask" must be a string or list, got {type(mask).__name__}')
+        # An explicit "I cannot ground this" is a better answer than a mask that
+        # resolves and means the wrong thing, so it is surfaced rather than
+        # retried into something more confident.
+        if 'insufficient_information' in payload:
+            raise ParseError(
+                f'the request could not be grounded in this model: '
+                f'{payload["insufficient_information"]}'
+            )
+
+        if 'constraints' in payload:
+            if self._schema is None:
+                raise ParseError(
+                    'no ForestModel was supplied, so the number of themes is '
+                    'unknown and the mask cannot be assembled'
+                )
+            try:
+                return self._schema.assemble(payload['constraints'])
+            except ThemeError as exc:
+                raise ParseError(str(exc)) from None
+
+        if 'mask' in payload:
+            mask = payload['mask']
+            if isinstance(mask, str):
+                return tuple(mask.lower().split())
+            if isinstance(mask, list):
+                return tuple(str(m).lower() for m in mask)
+            raise ParseError(
+                f'"mask" must be a string or list, got {type(mask).__name__}'
+            )
+
+        raise ParseError('expected a JSON object containing a "constraints" key')
 
     def validate(self, candidate: tuple, context: Any) -> Verdict:
         """
@@ -163,39 +246,19 @@ class BuildMask(Capability[tuple]):
             return Verdict.invalid(f'mask could not be resolved: {type(exc).__name__}: {exc}')
 
         if not matches:
-            unknown = self._unknown_codes(candidate, context)
-            detail = (
-                f'; these codes are not defined for their theme: {", ".join(unknown)}'
-                if unknown else ''
-            )
+            unknown = ThemeSchema.from_model(context).unknown_codes(candidate)
+            detail = ('; ' + '; '.join(unknown)) if unknown else ''
             return Verdict.invalid(
                 f'mask matches zero development types{detail}'
             )
 
         return Verdict.valid()
 
-    @staticmethod
-    def _unknown_codes(mask: tuple, fm: Any) -> list[str]:
-        """
-        Identify codes absent from their theme.
-
-        Turns "matched nothing" into an actionable reason, which is what the retry
-        needs in order to do better than re-rolling.
-        """
-        unknown = []
-        for index, code in enumerate(mask):
-            if code == '?':
-                continue
-            if index < len(fm._themes) and code not in fm._themes[index]:
-                unknown.append(f'position {index}: {code!r}')
-        return unknown
-
     def __init__(self, fm: Optional[Any] = None) -> None:
         """
-        :param fm: Optional model used to describe themes in the prompt. When
-            omitted the prompt omits the code listing and the model must guess,
-            which the validator will usually reject.
+        :param fm: Model supplying the theme schema. The theme count is what makes
+            mask assembly deterministic, so without a model the capability can
+            describe nothing and assemble nothing.
         """
         super().__init__()
-        self._nthemes = fm.nthemes() if fm is not None else 'an unknown number of'
-        self._themes = _theme_summary(fm) if fm is not None else '  (not available)'
+        self._schema: Optional[ThemeSchema] = schema_for(fm)

--- a/ws3/agent/capabilities/diagnose_import.py
+++ b/ws3/agent/capabilities/diagnose_import.py
@@ -101,6 +101,23 @@ class DiagnoseImport(Capability[Diagnosis]):
             excerpt=str(payload.get('excerpt', '')),
         )
 
+    def coerce_input(self, inputs: Any) -> ImportFailure:
+        """
+        Accept a dict as well as an :py:class:`ImportFailure`.
+
+        No string shorthand here: this capability needs the model path and section
+        to run its oracle at all, so there is no single field that could stand in
+        for the rest.
+        """
+        if isinstance(inputs, ImportFailure):
+            return inputs
+        if isinstance(inputs, dict):
+            return self.from_payload(inputs)
+        raise TypeError(
+            f'diagnose_import takes a dict or an ImportFailure; '
+            f'got {type(inputs).__name__}'
+        )
+
     def render(self, value: 'Diagnosis') -> str:
         """Render the diagnosis and the verified replacement line."""
         return (

--- a/ws3/agent/capabilities/explain_exception.py
+++ b/ws3/agent/capabilities/explain_exception.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import importlib
 import json
 import re
+import traceback
 from dataclasses import dataclass
 from typing import Any, Iterable
 
@@ -152,6 +153,34 @@ class ExplainException(Capability[Explanation]):
             message=str(payload.get('message', '')),
             traceback_text=str(payload.get('traceback_text', '')),
             context=str(payload.get('context', '')),
+        )
+
+    def coerce_input(self, inputs: Any) -> ExceptionReport:
+        """
+        Accept a live exception as well as an :py:class:`ExceptionReport`.
+
+        Passing the caught exception straight through is the obvious call at a
+        ``except`` site, and it also captures the traceback automatically -- which
+        materially improves the explanation, and which a hand-built report usually
+        omits.
+        """
+        if isinstance(inputs, ExceptionReport):
+            return inputs
+        if isinstance(inputs, BaseException):
+            return ExceptionReport(
+                exc_type=type(inputs).__name__,
+                message=str(inputs),
+                traceback_text=''.join(
+                    traceback.format_exception(
+                        type(inputs), inputs, inputs.__traceback__
+                    )
+                ),
+            )
+        if isinstance(inputs, dict):
+            return self.from_payload(inputs)
+        raise TypeError(
+            f'explain_exception takes an Exception, a dict, or an ExceptionReport; '
+            f'got {type(inputs).__name__}'
         )
 
     def render(self, value: 'Explanation') -> str:

--- a/ws3/agent/themes.py
+++ b/ws3/agent/themes.py
@@ -1,0 +1,251 @@
+"""
+Theme structure of a :py:class:`~ws3.forest.ForestModel`, for agent capabilities.
+
+The Woodstock model format is deliberately open ended: the user declares their own
+set of themes, and their own set of stratification variable codes within each
+theme. Nothing about that vocabulary is known ahead of time, and much of ws3's
+internal complexity follows from it.
+
+Two consequences drive this module:
+
+**Theme count is structural.** The number of themes fixes the length of every
+development-type key, and therefore of every mask, in a given model instance. It
+is authoritative state, read from the LANDSCAPE section of the input dataset (or
+from whatever built the model). A capability that asks a language model to
+reproduce it has invented a failure mode: a live 9B model duly returned a
+ten-entry mask for a five-theme model. Masks are assembled here, from sparse
+constraints, so the arity is correct by construction rather than by policing.
+
+**The code vocabulary belongs to the user.** No fixed set of codes is ever valid
+across models, so prompts must carry the instance's actual vocabulary and
+validation must resolve against the instance. Aggregates matter especially: an
+aggregate is a name the user chose for a group of codes, so it is usually the
+closest thing in the model to the words a person will use when describing the
+stands they mean.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+#: Cap on codes listed per theme in a prompt. Real models can carry hundreds;
+#: listing all of them buries the task and wastes context.
+MAX_CODES_PER_THEME = 40
+
+#: Cap on members listed when expanding an aggregate in a prompt.
+MAX_AGGREGATE_MEMBERS = 12
+
+#: Mask entry matching any code in a theme position.
+WILDCARD = '?'
+
+
+class ThemeError(ValueError):
+    """A theme position or code that does not exist in this model instance."""
+
+
+@dataclass(frozen=True)
+class Theme:
+    """
+    One theme of a model instance.
+
+    :param index: Position in the development-type key.
+    :param name: Theme name, e.g. ``theme0``.
+    :param description: Theme description, often empty.
+    :param basecodes: Codes the user declared directly.
+    :param aggregates: Aggregate code to the codes it stands for.
+    """
+
+    index: int
+    name: str
+    description: str
+    basecodes: tuple[str, ...]
+    aggregates: dict[str, tuple[str, ...]]
+
+    def known(self, code: str) -> bool:
+        """Whether *code* is a basecode or an aggregate of this theme."""
+        return code in self.basecodes or code in self.aggregates
+
+    def codes(self) -> tuple[str, ...]:
+        """Every code valid in this theme position, basecodes and aggregates."""
+        return self.basecodes + tuple(self.aggregates)
+
+
+class ThemeSchema:
+    """
+    The theme structure of one model instance.
+
+    Built from a :py:class:`~ws3.forest.ForestModel`; carries no reference to it,
+    so it is safe to hold, describe and diff.
+    """
+
+    def __init__(self, themes: tuple[Theme, ...]) -> None:
+        self.themes = themes
+
+    @classmethod
+    def from_model(cls, fm: Any) -> 'ThemeSchema':
+        """
+        Read the theme structure out of a model.
+
+        Basecodes and aggregates are distinguished by the shape of the stored
+        value -- ws3 stores a basecode as ``{code: code}`` and an aggregate as
+        ``{code: [members]}`` -- rather than via
+        :py:meth:`~ws3.forest.ForestModel.theme_basecodes`, because that parallel
+        list is only appended to when a theme is declared with a non-empty
+        basecode list, so it can fall out of step with ``_themes``.
+        """
+        themes = []
+        for index, raw in enumerate(fm._themes):
+            basecodes = []
+            aggregates = {}
+            for code, value in raw.items():
+                if code.startswith('__'):
+                    continue
+                if isinstance(value, (list, tuple, set)):
+                    aggregates[code] = tuple(value)
+                else:
+                    basecodes.append(code)
+            themes.append(
+                Theme(
+                    index=index,
+                    name=raw.get('__name__', f'theme{index}'),
+                    description=raw.get('__description__', ''),
+                    basecodes=tuple(basecodes),
+                    aggregates=aggregates,
+                )
+            )
+        return cls(tuple(themes))
+
+    def __len__(self) -> int:
+        return len(self.themes)
+
+    @property
+    def nthemes(self) -> int:
+        """Number of themes, and so the length of every development-type key."""
+        return len(self.themes)
+
+    def wildcard_mask(self) -> tuple[str, ...]:
+        """A mask matching every development type in the model."""
+        return tuple([WILDCARD] * self.nthemes)
+
+    def assemble(self, constraints: dict[Any, Any]) -> tuple[str, ...]:
+        """
+        Expand sparse theme constraints into a full-length mask.
+
+        Positions not mentioned become wildcards, so the result always has exactly
+        one entry per theme regardless of what was supplied. This is what keeps
+        mask arity out of a language model's hands.
+
+        :param constraints: Theme position to code. Keys may be ``int`` or the
+            string form of one.
+        :raises ThemeError: If a position is not an integer or is out of range.
+        """
+        if not isinstance(constraints, dict):
+            raise ThemeError(
+                f'constraints must be a mapping of theme position to code, got '
+                f'{type(constraints).__name__}'
+            )
+
+        mask = list(self.wildcard_mask())
+        for key, code in constraints.items():
+            mask[self._position(key)] = str(code).lower()
+        return tuple(mask)
+
+    def _position(self, key: Any) -> int:
+        """
+        Resolve a constraint key to a valid theme index.
+
+        Accepts the position number or the theme's name. The listing shown to a
+        model puts both in front of it, and a model that keys by the name is not
+        wrong about the theme -- only about the notation. Names are unambiguous
+        here, so resolving them is deterministic rather than a guess, and it costs
+        nothing compared with a retry.
+        """
+        if isinstance(key, str):
+            name = key.strip().lower()
+            for theme in self.themes:
+                if theme.name.lower() == name:
+                    return theme.index
+
+        try:
+            index = int(key)
+        except (TypeError, ValueError):
+            names = ', '.join(t.name for t in self.themes)
+            raise ThemeError(
+                f'theme position {key!r} is not a position number or a known theme '
+                f'name; use one of the position numbers 0 to {self.nthemes - 1}, '
+                f'or one of: {names}'
+            ) from None
+        if not 0 <= index < self.nthemes:
+            raise ThemeError(
+                f'theme position {index} is out of range; this model has '
+                f'{self.nthemes} themes, numbered 0 to {self.nthemes - 1}'
+            )
+        return index
+
+    def unknown_codes(self, mask: tuple[str, ...]) -> list[str]:
+        """
+        Describe mask entries that are not codes of their theme.
+
+        Turns "matched nothing" into something a retry can act on, and names what
+        would have worked -- the vocabulary is user-defined, so the model cannot
+        infer it.
+        """
+        problems = []
+        for index, code in enumerate(mask):
+            if code == WILDCARD or index >= self.nthemes:
+                continue
+            theme = self.themes[index]
+            if theme.known(code):
+                continue
+            valid = list(theme.codes())
+            shown = ', '.join(valid[:MAX_CODES_PER_THEME]) or '(none)'
+            suffix = '' if len(valid) <= MAX_CODES_PER_THEME else ' ...'
+            problems.append(
+                f'position {index} ({theme.name}): {code!r} is not a code for this '
+                f'theme (valid: {shown}{suffix})'
+            )
+        return problems
+
+    def describe(self) -> str:
+        """
+        Render the theme vocabulary for a prompt.
+
+        Aggregates are listed separately and expanded, because an aggregate is a
+        name the user chose for a group of stands and is therefore the code most
+        likely to match how a person describes them.
+
+        A theme with no description is marked as such. ``import_landscape_section``
+        names themes ``theme0``, ``theme1`` and so on; those are positional
+        placeholders carrying no meaning, and saying so is the difference between
+        selecting on evidence and pattern-matching on a number.
+        """
+        lines = []
+        for theme in self.themes:
+            header = f'  position {theme.index} ({theme.name})'
+            if theme.description:
+                header += f' -- {theme.description}'
+            else:
+                header += ' -- undescribed, no stated meaning'
+            lines.append(header + ':')
+
+            shown = list(theme.basecodes[:MAX_CODES_PER_THEME])
+            suffix = (
+                '' if len(theme.basecodes) <= MAX_CODES_PER_THEME
+                else f' ... ({len(theme.basecodes)} total)'
+            )
+            lines.append(f'      codes: {", ".join(shown) or "(none)"}{suffix}')
+
+            for name, members in theme.aggregates.items():
+                listed = ', '.join(members[:MAX_AGGREGATE_MEMBERS])
+                more = (
+                    '' if len(members) <= MAX_AGGREGATE_MEMBERS
+                    else f' ... ({len(members)} total)'
+                )
+                lines.append(f'      aggregate {name}: {listed}{more}')
+        return '\n'.join(lines)
+
+
+def schema_for(fm: Optional[Any]) -> Optional[ThemeSchema]:
+    """Return the schema for *fm*, or ``None`` if no model was supplied."""
+    return None if fm is None else ThemeSchema.from_model(fm)

--- a/ws3/data/woodstock_format.yaml
+++ b/ws3/data/woodstock_format.yaml
@@ -1,0 +1,2781 @@
+keywords:
+  '*A':
+    arguments:
+    - StartAge
+    - AreaValue
+    article_id: '737'
+    syntax:
+    - '*A mask age AreaValue [_LOCK Number or _NA Interval]'
+    - '*A mask StartAge AreaValue1 AreaValue2 ...'
+    used_in:
+    - Areas
+  '*AA':
+    arguments:
+    - Aacode
+    article_id: '738'
+    syntax:
+    - '*AA mask age area aacode [_LOCK Number or _NA Interval]'
+    used_in:
+    - Areas
+  '*AACONTROL':
+    arguments:
+    - Switch
+    - ActionCode
+    - PercentOperable
+    article_id: '739'
+    syntax:
+    - '*AACONTROL Switch [ActionCode] [PercentOperable] [_BINARY]'
+    - Woodstock
+    - Woodstock
+    - 'Rule(s):'
+    - •
+    - Woodstock
+    used_in:
+    - Control
+  '*ACTION':
+    arguments:
+    - ActionName
+    - DefaultAgeReset
+    - ActionDescription
+    - Mask1-X
+    - OperableCondition
+    article_id: '740'
+    syntax:
+    - '*ACTION ActionName DefaultAgeReset [ActionDescription]'
+    - '*OPERABLE ActionName'
+    - Mask1 OperableCondition1
+    - Mask2 OperableCondition2
+    - Maskn OperableConditionn
+    used_in:
+    - Actions
+  '*ADDCOMMENTSTOMATRIX':
+    article_id: '1795'
+  '*AGGREGATE':
+    article_id: '742'
+    syntax:
+    - 'Landscape section:'
+    - '*THEME [ThemeDescription]'
+    - BasicAttributeCode1 [AttributeDescription1]
+    - BasicAttributeCode2 [AttributeDescription2]
+    - BasicAttributeCoden [AttributeDescriptionn]*AGGREGATE AggregateAttributeCode1
+    - BasicCode1  BasicCode2
+    - '*AGGREGATE AggregateAttributeCode2'
+    - AggName1 BasicCoden
+    - 'Actions section:'
+    - '*ACTION ActionName1 DefaultAgeReset [ActionDescription]'
+    - '*ACTION ActionName2 DefaultAgeReset [ActionDescription]*AGGREGATE AggregateName1'
+    - ActionName1 ActionName2
+    - '*AGGREGATE AggregateName1'
+    - '*AGGREGATE(_TH1) AggregateAttributeCode1'
+    - BasicCode1
+    - BasicCode2
+    used_in:
+    - Landscape
+    - Actions
+    - Allocation
+  '*AODOWNGRADES':
+    arguments:
+    - Switch
+    article_id: '3086'
+    syntax:
+    - '*AODOWNGRADES Switch'
+  '*AVAILABLE':
+    arguments:
+    - ActionName
+    - YieldName
+    - EventArea
+    article_id: '743'
+    syntax:
+    - '*AVAILABLE ActionName'
+    - Mask YieldName EventArea
+    used_in:
+    - Queue
+  '*BUILD':
+    arguments:
+    - Switch
+    article_id: '744'
+    syntax:
+    - '*BUILD Switch'
+    used_in:
+    - Control
+  '*CACHEDLLCALLS':
+    article_id: '1739'
+  '*CASE':
+    arguments:
+    - ActionName
+    article_id: '745'
+    syntax:
+    - '*CASE ActionName'
+    - '*SOURCE mask'
+    - '*TARGET mask percent'
+    used_in:
+    - Transitions
+  '*COMPRESSTIME':
+    arguments:
+    - StartPeriod
+    - PeriodWidth
+    article_id: '746'
+    syntax:
+    - '*COMPRESSTIME StartPeriod,PeriodWidth,StartPeriod,PeriodWidth'
+    used_in:
+    - Control
+  '*CONSTRAINTS':
+    article_id: '747'
+    syntax:
+    - '*CONSTRAINTS'
+    used_in:
+    - Optimize
+    - Allocation
+  '*CUTCOMPLETECLASS':
+    arguments:
+    - Switch
+    - Interval
+    - ActionName
+    - Aggregatename
+    article_id: '748'
+    syntax:
+    - '*CUTCOMPLETECLASS Switch [Actionname or Aggregatename]'
+    - OR
+    - '*CUTCOMPLETECLASS Interval [Actionname or Aggregatename]'
+    used_in:
+    - Control
+  '*DEBUG':
+    arguments:
+    - Switch
+    article_id: '749'
+    syntax:
+    - '*DEBUG Switch [YieldName1,YieldName2,YieldNameN]'
+    used_in:
+    - Control
+  '*DEFINE':
+    arguments:
+    - DefineName
+    - Product
+    - Outputn
+    article_id: '1815'
+    syntax:
+    - '*DEFINE DefineName<(_AGE)>'
+    - Product = Output1 / Output2
+    used_in:
+    - Allocation
+  '*DELIVER':
+    arguments:
+    - Period
+    - Volume
+    - Product
+    - Origin
+    - Destination
+    article_id: '947'
+    syntax:
+    - '*DELIVER Period Volume Product Origin Destination'
+    used_in:
+    - Schedule
+  '*DESTINATION':
+    article_id: '750'
+    syntax:
+    - 'Structure:'
+    - '*DESTINATION Name Description'
+    - _INPUTS ProductName MinVolume MaxVolume MinPercent MaxPercent
+    - _OUTPUTS ResidualName <- ConversionFactor ProductName
+    - _CAPACITIES MinVolume MaxVolume
+    - _INVALIDORIGINS Origin1,Origin2, OriginN
+    used_in:
+    - Allocation
+  '*EXCLUDE':
+    arguments:
+    - Interval
+    article_id: '751'
+    syntax:
+    - 'Areas section:'
+    - '*EXCLUDE'
+    - Mask1 Interval
+    - Mask2 Interval
+    - 'Optimize section:'
+    - '*EXCLUDE'
+    - ActionName1 Interval
+    - ActionName2 Interval
+    used_in:
+    - Areas
+    - Optimize
+  '*EXTERNAL':
+    arguments:
+    - ProductName
+    - MinVolume
+    - MaxVolume
+    article_id: '752'
+    syntax:
+    - '*EXTERNAL Source -> ProductName MinVolume MaxVolume'
+    used_in:
+    - Allocation
+  '*FORMAT':
+    arguments:
+    - SolverName
+    article_id: '756'
+    syntax:
+    - '*FORMAT SolverName'
+    used_in:
+    - Optimize
+  '*GRAPHICS':
+    arguments:
+    - Switch
+    article_id: '757'
+    syntax:
+    - '*GRAPHICS Switch'
+    used_in:
+    - Control
+  '*GROUP':
+    arguments:
+    - GroupName
+    - ConstantDeclaration
+    article_id: '1395'
+    syntax:
+    - 'Constants Section:'
+    - '*GROUP GroupName'
+    - ConstantDeclaration1
+    - ConstantDeclaration2
+    used_in:
+    - Constants. Outputs. Optimize. Yields
+  '*HIDDEN':
+    arguments:
+    - Mask
+    - Interval
+    article_id: '1431'
+    syntax:
+    - '*HIDDEN'
+    - Mask Interval
+    used_in:
+    - Areas
+  '*IMAGE':
+    arguments:
+    - Switch
+    article_id: '758'
+    syntax:
+    - '*IMAGE Switch'
+    used_in:
+    - Control
+  '*INCLUDE':
+    arguments:
+    - FileName
+    - Extension
+    article_id: '1748'
+    syntax:
+    - '*INCLUDE FileName.Extension'
+    used_in:
+    - All
+  '*INCLUDEIF':
+    arguments:
+    - PropertyName
+    - Operator
+    - SourceScenario
+    article_id: '3103'
+    syntax:
+    - '*INCLUDEIF (_PROPERTIES(PropertyName) operator Value) (SourceScenario) FileName.ext'
+    used_in:
+    - All
+  '*INVENTORY':
+    arguments:
+    - Destination
+    - Product
+    - Volume
+    - Period
+    article_id: '948'
+    syntax:
+    - '*INVENTORY Destination Product Volume Period'
+    used_in:
+    - Schedule
+  '*LENGTH':
+    arguments:
+    - Value
+    article_id: '760'
+    syntax:
+    - '*LENGTH Value'
+    used_in:
+    - Control
+  '*LEVEL':
+    arguments:
+    - LevelName
+    - LevelDescription
+    article_id: '761'
+    syntax:
+    - Unsourced
+    - '*LEVEL LevelName[(_THn)] Level Description'
+    - Sourced basic
+    - '*LEVEL LevelName Level Description'
+    - '*SOURCE <[P0]> Value1 <[P1]> Value2 <[P2]> Value3 ... <[Pn]> Valuen'
+    - Sourced theme-based
+    - '*LEVEL LevelName(_THn) Level Description'
+    - '*SOURCE (ThemeAttribute1) <[P0]> Value1 <[P1]> Value2 <[P2]> Value3 ... <[Pn]> Valuen'
+  '*LPSCHEDULE':
+    arguments:
+    - Switch
+    article_id: '763'
+    syntax:
+    - '*LPSCHEDULE Switch'
+    - '*LPSCHEDULE Interval'
+    used_in:
+    - Control
+  '*MINAREA':
+    arguments:
+    - Value
+    article_id: '764'
+    syntax:
+    - '*MINAREA Value'
+    used_in:
+    - Control
+  '*N':
+    arguments:
+    - TotalArea
+    - StartAge
+    article_id: '765'
+    syntax:
+    - '*A mask'
+    - '*N TotalArea'
+    used_in:
+    - Areas
+  '*NEGVOL':
+    arguments:
+    - Value
+    article_id: '766'
+    syntax:
+    - '*NEGVOL Value'
+    used_in:
+    - Control
+  '*OBJECTIVE':
+    arguments:
+    - ObjectiveSense
+    - Interval
+    - Constant
+    article_id: '767'
+    syntax:
+    - '*OBJECTIVE'
+    - ObjectiveSense f(Output1,Output2,..[Constant] * OutputX) Interval
+    used_in:
+    - Optimize
+  '*OPERABLE':
+    arguments:
+    - ActionName
+    - DefaultAgeReset
+    - ActionDescription
+    - Interval
+    - Mask1-X
+    - OperableCondition
+    - RegimeName
+    - OperableCondition1-X
+    - PrescriptionName
+    - Mask
+    article_id: '768'
+    syntax:
+    - 'Actions section:'
+    - '*ACTION ActionName DefaultAgeReset [ActionDescription]'
+    - '*OPERABLE ActionName [_CP Interval]'
+    - Mask1 OperableCondition1
+    - Mask2 OperableCondition2
+    - MaskX OperableConditionX
+    - _CP is a keyword to reference the current planning period,
+    - 'Regimes section:'
+    - '*REGIME Regime Name'
+    - '*OPERABLE RegimeName [_CP Interval]'
+    - Mask1 OperableCondition1
+    - Mask2 OperableCondition2
+    - MaskX OperableConditionX
+    - _CP is a keyword to reference the current planning period,
+    - '*PRESCRIPTION Prescription Name'
+    - '*OPERABLE Mask1 OperableCondition1'
+    - Mask2 OperableCondition2
+    - MaskX OperableConditionX
+    - _CP is a keyword to reference the current planning period,
+    used_in:
+    - Actions
+    - Regimes
+  '*OPERABLEINVENTORYBYPRESCRIPTION':
+    article_id: '3059'
+  '*OPTIMIZE':
+    arguments:
+    - Switch
+    - StartPeriod
+    - CommandLineToken
+    article_id: '769'
+    syntax:
+    - '*OPTIMIZE Switch or [StartPeriod] or [CommandLineToken]'
+    used_in:
+    - Control
+  '*ORIGIN':
+    arguments:
+    - THEMEx
+    article_id: '770'
+    syntax:
+    - '*ORIGIN _THEMEx'
+    used_in:
+    - Allocation
+  '*OUTPUT':
+    arguments:
+    - OutputName
+    - mask
+    - AreaLookup
+    - ValueToSum
+    article_id: '771'
+    syntax:
+    - 'Basic output:'
+    - '*OUTPUT OutputName(_THx) OutputDescription'
+    - 'Summary output:'
+    - '*OUTPUT OutputName(_THx) OutputDescription'
+    - '*SOURCE OutputName1 [×, ÷ Constant or TimeYield]'
+    - '*SOURCE OutputName1 +, - OutputName2 +,-  ...'
+    - 'Rule(s):'
+    - 'Examples of general formulation:'
+    - 'Basic outputs:'
+    - 'Action outputs:'
+    - '*OUTPUT oHarvestVolume Total volume harvested'
+    - '*SOURCE ? ? ? aClearcut yTRV + ? ? ? aLightThin'
+    - '*OUTPUT oHarvestVolume(_TH3) Total volume harvested'
+    - '*SOURCE ? ? ? aClearcut yTRV  + ? ? ? aLightThin'
+    - '*OUTPUT oTotalClearcutAge Total sum of clearcut ages'
+    - '*SOURCE ? ? ? aClearcut _AGE'
+    - '*OUTPUT oAreaClearcut Total area clearcut'
+    - '*SOURCE ? ? ? aClearcut _AREA'
+    - '*OUTPUT oTotalRevenue Total revenue'
+    - '*SOURCE ? ? ? aClearcut      yPulp *   yPulp$ +'
+    - '? ? ? aLightThin   yLTPulp *   yPulp$ +'
+    - '? ? ? aHeavyThin   yHTPulp *   yPulp$ +'
+    - '? ? ? aClearcut      yLogs *   yLogs$ +'
+    - '? ? ? aLightThin   yLTLogs *   yLogs$ +'
+    - '? ? ? aHeavyThin   yHTLogs *   yLogs$ +'
+    - '? ? ? aClearcut    yVeneer * yVeneer$ +'
+    - '? ? ? aLightThin yLTVeneer * yVeneer$ +'
+    - '? ? ? aHeavyThin yHTVeneer * yVeneer$'
+    - 'Inventory outputs:'
+    - '*OUTPUT oGrowingstock Total standing inventory'
+    - '*SOURCE ? ? ?  _INVENT yTRV'
+    - '*OUTPUT oOperableStock Standing inventory available for harvest'
+    - '*SOURCE ? ? ? _INVENT(aClearcut)    yTRV +'
+    - '? ? ? _INVENT(aLightThin,aHeavyThin) yhttrv'
+    - 'Summary outputs:'
+    - '*OUTPUT oPVTotalRev Present value of total revenue'
+    - '*SOURCE oTotalRevenue * yDisc10%'
+    - '*OUTPUT oAvgClearcutAge Area-weighted average clearcut age'
+    - '*SOURCE oTotalClearcutAge / oAreaClearcut'
+    - '*OUTPUT oNPV Net income'
+    - '*SOURCE oPVTotalRev - oPVTotalCost'
+    used_in:
+    - Outputs
+  '*P':
+    arguments:
+    - Mask
+    - Percent
+    - StartAge
+    - Percent1-3
+    article_id: '772'
+    syntax:
+    - 'Areas section:'
+    - '*A mask'
+    - '*P percent'
+    - 'Yields section:'
+    - '*Y or *YT mask'
+    - '*P percent'
+    - '*P percent'
+    - '*Y or *YT mask'
+    - _AGE or   _CP   YieldName1 YieldName2 YieldName3 ...
+    - '*P                    percent1     percent2       percent3'
+    - Age1     Period1    Value1       Value1          Value1
+    - Age2     Period2    Value2       Value2          Value2
+    - Age3     Period3    Value3       Value3          Value3
+    - Woodstock
+    used_in:
+    - Areas
+    - Yields
+  '*PARTIAL':
+    arguments:
+    - ActionName
+    - YieldTable
+    article_id: '774'
+    syntax:
+    - '*ACTION ActionName DefaultAgeReset [ActionDescription]'
+    - '*OPERABLE ActionName'
+    - Mask1 OperableCondition1
+    - Mask2 OperableCondition2
+    - Maskn OperableConditionn
+    - '*PARTIAL ActionName'
+    - YieldTable1 YieldTable2 YieldTable3
+    used_in:
+    - Actions
+  '*PAUSE':
+    arguments:
+    - Value
+    article_id: '775'
+    used_in:
+    - Control
+  '*PAUSEWHENDONE':
+    arguments:
+    - Switch
+    article_id: '776'
+    syntax:
+    - '*PAUSEWHENDONE Switch'
+    used_in:
+    - Control
+  '*PERIODS':
+    arguments:
+    - UnitDescription
+    article_id: '1458'
+    syntax:
+    - '*PERIODS  UnitDescription'
+    - _CP[1]   Label1
+    - _CP[2]   Label2
+    - _CP[n]   Labeln
+    - Woodstock
+    used_in:
+    - Control
+  '*PRESCRIPTION':
+    arguments:
+    - RegimeName
+    - PrescriptionName
+    - ActionName
+    - EntryType
+    - Value
+    article_id: '777'
+    syntax:
+    - '*PRESCRIPTION'
+    - '*REGIME RegimeName'
+    - '*OPERABLE RegimeOperabilityRule1'
+    - RegimeOperabilityRule2
+    - '*PRESCRIPTION PrescriptionName'
+    - '*Operable PrescriptionOperabilityRule1'
+    - '[*TARGET TargetMask1 Percent1'
+    - TargetMask2 Percent2]
+    - _RXPERIOD _ACTION _ENTRY [YieldName]
+    - Period1 ActionName EntryType [Value]
+    - Period2 ActionName EntryType [Value]
+    used_in:
+    - Regimes
+  '*PROCESS':
+    arguments:
+    - Destination
+    - Product
+    - Origin
+    - Period
+    article_id: '946'
+    syntax:
+    - '*PROCESS Destination Product Volume Period'
+    used_in:
+    - Schedule
+  '*PRODUCT':
+    arguments:
+    - OutputName
+    - Proportion
+    - ProductName
+    article_id: '778'
+    syntax:
+    - Product shipped unchanged
+    - '*PRODUCT OutputName'
+    - 'Product with fixed conversion:'
+    - '*PRODUCT OutputName -> Proportion ProductName1,[ Proportion ProductName2,]...'
+    - '[-> Proportion ProductName3,[ Proportion ProductName4,]...]'
+    - 'Product with optional conversion:'
+    - '*PRODUCT OutputName -> 1 Outputname'
+    - '[-> Proportion ProductName3,[ Proportion ProductName4,]...]'
+    - 'Product with downgrade:'
+    - '*PRODUCT OutputName -> 1 Outputname'
+    - -> 1.0 »ProductName1
+    - '[-> 1.0 »ProductName2]'
+    - '[-> 1.0 »ProductNameN]'
+    - Woodstock
+    - Woodstock
+  '*QUEUE':
+    arguments:
+    - Switch
+    article_id: '779'
+    syntax:
+    - '*QUEUE Switch'
+    used_in:
+    - Control
+  '*REGIME':
+    arguments:
+    - RegimeName
+    - PrescriptionName
+    - ActionName
+    - EntryType
+    - Value
+    article_id: '780'
+    syntax:
+    - 'Regimes section:'
+    - '*REGIME RegimeName'
+    - '*PRESCRIPTION PrescriptionName'
+    - '*OPERABLE OperabilityRule1'
+    - OperabilityRule2
+    - '[*TARGET TargetMask1 Percent1'
+    - TargetMask2 Percent2]
+    - _RXPERIOD _ACTION _ENTRY [YieldName]
+    - Period1 ActionName EntryType [Value]
+    - Period2 ActionName EntryType [Value]
+    - 'Actions section:'
+    - '*REGIME RegimeName'
+    - 'Rule(s):'
+    used_in:
+    - Regimes. Actions
+  '*REPORTS':
+    arguments:
+    - Switch
+    article_id: '781'
+    syntax:
+    - '*REPORTS Switch'
+    used_in:
+    - Control
+  '*RESIDUALS':
+    arguments:
+    - ResidualName
+    article_id: '782'
+    syntax:
+    - '*RESIDUALS ResidualName, ResidualName1,…'
+    used_in:
+    - Allocation
+  '*RUNS':
+    arguments:
+    - Number
+    article_id: '783'
+    syntax:
+    - '*RUNS Number'
+    used_in:
+    - Control
+  '*SCHEDULE':
+    arguments:
+    - Switch
+    - Interval
+    article_id: '785'
+    syntax:
+    - '*SCHEDULE Switch'
+    - '*SCHEDULE Interval'
+    used_in:
+    - Control
+  '*SELECT':
+    arguments:
+    - ActionName
+    article_id: '787'
+    syntax:
+    - '*SELECT ActionName'
+    - Rule1
+    - Rule2
+    - Rule3
+    - …
+    used_in:
+    - Queue
+  '*SEQUENCES':
+    article_id: '3038'
+    used_in:
+    - where Theme 8 represents harvest unit
+    - beginning with harvest unit S1004
+    - where Theme 8 represents harvest unit
+  '*SEQUENCETOSEQUENCE':
+    article_id: '3039'
+  '*SLACK':
+    arguments:
+    - Switch
+    article_id: '788'
+    syntax:
+    - '*SLACK Switch'
+    used_in:
+    - Control
+  '*SMALLCHOICESFILE':
+    article_id: '3055'
+  '*SOURCE':
+    arguments:
+    - ActionName
+    - mask1-4
+    - percent
+    - Mask
+    - OutputName
+    - AreaLookup
+    - ValueToSum
+    - OutputName1-2
+    - Constant
+    - AO_Output
+    - TimeYield
+    article_id: '789'
+    syntax:
+    - 'Transitions section:'
+    - '*CASE ActionName'
+    - '*SOURCE mask1'
+    - '*TARGET mask2 percent'
+    - '*SOURCE mask3'
+    - '*TARGET mask4 percent'
+    - '*TARGET mask4 percent'
+    - …
+    - 'Queue section:'
+    - '*TARGET OutputName =,<=,>= Value Interval [_MAX]   *SOURCE [mask] ActionName Percent'
+    - '*SOURCE [mask] ActionName Percent'
+    - 'Outputs section:'
+    - '*OUTPUT OutputName[_THx] OutputDescription *SOURCE [mask1] [@AGE or @YLD] AreaLookUp ValueToSum
+      [×, ÷ Constant or TimeYield] +'
+    - 'Summary output:'
+    - '*OUTPUT OutputName[_THx] OutputDescription *SOURCE OutputName1 [×, ÷ Constant or TimeYield]'
+    - '*SOURCE OutputName1 +, - OutputName2 +,-  ...'
+    - '*SOURCE AO_Output'
+    used_in:
+    - Transitions
+    - Queue
+    - Outputs
+  '*STRATA':
+    arguments:
+    - Mask
+    - Area
+    article_id: '1432'
+    syntax:
+    - '*STRATA mask area'
+    used_in:
+    - Schedule
+  '*TABLE':
+    arguments:
+    - TableName
+    - Index1-4
+    - Index1-4Value
+    - TableValue
+    article_id: '791'
+    syntax:
+    - '*TABLE TableName(_Index1[,_Index2,_Index3,_Index4])'
+    - Index1Value [Index2Value Index3Value Index4Value]  TableValue
+    used_in:
+    - Allocation
+  '*TARGET':
+    arguments:
+    - Percent1-2
+    - Number
+    - AgeValue
+    - YieldName
+    - YieldValue
+    - Mask1-3
+    - OutputName
+    - Value
+    - Interval
+    - FileName
+    - EXT
+    - OutputName1-3
+    - VariableName
+    - yTimeYield
+    - f
+    - SystemReport
+    - YieldTableName1-2
+    article_id: '792'
+    syntax:
+    - 'Transitions section:'
+    - '*CASE ActionName'
+    - '*SOURCE mask1'
+    - '*TARGET mask2 percent1 [_LOCK Number]'
+    - '*TARGET mask3 percent2 [_AGE AgeValue or YieldName YieldValue]'
+    - '*TARGET mask4 percent3 [_REPLACE(_THx,string) or _APPEND(_THx,string)]'
+    - '*SOURCE mask5'
+    - '*TARGET mask6 percent1'
+    - '*TARGET mask7 percent2'
+    - 'Regimes section:'
+    - '*PRESCRIPTION PrescriptionName'
+    - '*OPERABLE mask1 condition'
+    - '*TARGET mask2 percent1 [_LOCK Number]'
+    - '*TARGET mask3 percent1 [_AGE AgeValue or YieldName YieldValue]'
+    - '*TARGET mask4 percent2 [_REPLACE(_THx,string) or _APPEND(_THx,string)]'
+    - 'Queue section:'
+    - '*TARGET OutputName =,<=,>= Value Interval [_MAX or _MIN]'
+    - '*SOURCE [mask] ActionName Percent'
+    - '*SOURCE [mask] ActionName Percent'
+    - 'Reports section:'
+    - '*TARGET FileName.EXT [_FORM2] [_RESET n] [_PROPERTIES(PropertyName)]'
+    - OutputName1 Interval
+    - OutputName2 Interval
+    - OutputName3 * yTimeYield Interval
+    - VariableName Interval
+    - _SUM(OutputName) Interval
+    - _MIN(OutputName) Interval
+    - _MAX(OutputName)  Interval
+    - _AVG(OutputName)  Interval
+    - …
+    - SystemReport Interval
+    - YieldTableName1 [Interval]
+    - YieldTableName2 [Interval]
+  '*THEME':
+    arguments:
+    - ThemeDescription
+    article_id: '793'
+    syntax:
+    - 'Landscape section:'
+    - '*THEME [ThemeDescription]'
+    - BasicAttributeCode1 [AttributeDescription1]
+    - BasicAttributeCode2 [AttributeDescription2]
+    - BasicAttributeCoden [AttributeDescriptionn]
+    - '*AGGREGATE AggregateAttributeCode1'
+    - BasicAttributeCode1  BasicAttributeCode2
+    - '*AGGREGATE AggregateAttributeCode2'
+    - AggName1 BasicAttributeCoden
+    - …
+    used_in:
+    - Landscape
+  '*TOLERANCE':
+    arguments:
+    - Number
+    - Percent
+    article_id: '794'
+    syntax:
+    - '*TOLERANCE Number or Percent'
+    used_in:
+    - Control
+  '*USECATEGORIES':
+    arguments:
+    - Switch
+    article_id: '719'
+    syntax:
+    - '*USECATEGORIES Switch'
+    - 'Rule(s):'
+    used_in:
+    - Control
+  '*USETHEMEDESCRIPTIONS':
+    article_id: '3036'
+    used_in:
+    - where it is declared in the Control
+    - 'set to “On”.  See Also: ALIASMODE'
+  '*VARIABLE':
+    arguments:
+    - VarName
+    - Keyword
+    article_id: '795'
+    syntax:
+    - '*VARIABLE'
+    - VarName [Keyword]
+    used_in:
+    - Optimize
+  '*WARNINGS':
+    arguments:
+    - Switch
+    - WarningCode
+    article_id: '797'
+    syntax:
+    - '*WARNINGS Switch [WarningCode1,WarningCode2…]'
+    used_in:
+    - Control
+  '*Y':
+    arguments:
+    - Mask
+    - StartAge
+    - Percent1-3
+    article_id: '799'
+    syntax:
+    - '*Y mask'
+    - '[*P percent]'
+    - '*Y mask'
+    - _AGE  YieldName1 YieldName2 YieldName3 ...
+    - '[*P        Percent1      Percent2       Percent3]'
+    - Age1     Value1         Value1          Value1
+    - Age2     Value2         Value2          Value2
+    - Age3     Value3         Value3          Value3
+    used_in:
+    - Yields
+  '*YC':
+    arguments:
+    - YieldName
+    - f
+    - YieldName1-2
+    article_id: '800'
+    syntax:
+    - '*YC mask'
+    - YieldName f(YieldName1,YieldName2…)
+    - '*YC mask _OVERRIDE'
+    - YieldName f(YieldName)
+    used_in:
+    - Yields
+  '*YT':
+    arguments:
+    - Mask
+    - StartPeriod
+    - Percent1-3
+    article_id: '802'
+    syntax:
+    - '*YT mask'
+    - '[*P percent]'
+    - '*YT mask'
+    - _CP      YieldName1 YieldName2 YieldName3 ...
+    - '[*P          Percent1      Percent2       Percent3]'
+    - Period1    Value1         Value1          Value1
+    - Period2    Value2         Value2          Value2
+    - Period3    Value3         Value3          Value3
+    used_in:
+    - Yields
+  '@AGE':
+    article_id: '607'
+    documented_as: '@AGE()'
+    syntax:
+    - 'Transitions section:'
+    - '*CASE Actioncode'
+    - '*SOURCE mask @AGE(agerange)'
+    - '*TARGET mask percent'
+    - 'Outputs section:'
+    - '*OUTPUT OutputName OutputDescription'
+    - '*SOURCE mask @AGE(agerange) AreaLookup ValueToSum'
+    used_in:
+    - Transitions
+    - Outputs
+  '@YLD':
+    arguments:
+    - YieldName
+    article_id: '730'
+    syntax:
+    - '*CASE ActionName'
+    - '*SOURCE mask @YLD(YieldName,ValueRange)'
+    - '*TARGET mask percent'
+    - '*OUTPUT OutputName OutputDescription'
+    - '*SOURCE mask @YLD(YieldName,ValueRange) AreaLookUp ValueToSum'
+    used_in:
+    - Transitions
+    - Outputs
+  Creating New Types (*NEWTYPES and *CREATE):
+    article_id: '1740'
+    used_in:
+    - delivery of products in short-term
+    - at yard
+    - at mill
+    - report on them
+    - display age class distributions
+    - apply actions to them.  Remember
+  _AA:
+    arguments:
+    - OutputName
+    - mask
+    - AreaLookup
+    - ValueToSum
+    - FileName
+    - EXT
+    - ActionName
+    - Interval
+    - OutputNamen
+    article_id: '803'
+    documented_as: _AA()
+    syntax:
+    - 'Outputs:'
+    - '*OUTPUT OutputName[_AA] Output Description'
+    - '*SOURCE [mask] AreaLookUp ValueToSum'
+    - 'Reports:'
+    - '*TARGET FileName.EXT'
+    - _AA[(ActionName)] Interval
+    - '[OutputName1][OutputName2]'
+    - 'Other activity schedule reports:'
+    - _ACTIVITY
+    - _DETAIL
+    used_in:
+    - Outputs
+    - Reports
+  _ACTION:
+    arguments:
+    - RegimeName
+    - PrescriptionName
+    - ActionName
+    - EntryType
+    - Value
+    - Enumerator
+    - Expression_Enumerator
+    article_id: '804'
+    syntax:
+    - 'Regimes:'
+    - '*REGIME RegimeName'
+    - '*PRESCRIPTION PrescriptionName'
+    - '*OPERABLE OperabilityRule1'
+    - OperabilityRule2
+    - '[*TARGET TargetMask1 Percent1'
+    - TargetMask2 Percent2]
+    - _RXPERIOD _ACTION _ENTRY [YieldName]
+    - Period1 ActionName EntryType [Value]
+    - Period2 ActionName EntryType [Value]
+    - 'Loops:'
+    - FOREACH Enumerator IN (_ACTION)
+    - Expression_Enumerator
+    - ENDFOR
+    used_in:
+    - Regimes
+    - Integrator/FOREACH loops (anywhere)
+  _ACTIVITY:
+    arguments:
+    - FileName
+    - EXT
+    - ActionName
+    - Interval
+    - OutputNamen
+    article_id: '805'
+    syntax:
+    - '*TARGET FileName.EXT'
+    - _ACTIVITY[(ActionName)] Interval
+    - '[OutputName1][OutputName2]'
+    - 'Example of declaration:'
+    - _ACTIVITY report for prescriptions
+    - 'Declaring an _ACTIVITY report in the Reports section:'
+    - ; Report
+    - '*TARGET MyActivityReport.dbf'
+    - _ACTIVITY 1.._LENGTH
+    - Example of prescriptions in an _ACTIVITY report
+    - '*REGIME Thin_And_CC'
+    - '*OPERABLE Thin_And_CC'
+    - '*PRESCRIPTION LightThinPrad@15'
+    - '*OPERABLE prad ? _AGE = 15'
+    - _RXPERIOD    _ACTION   _ENTRY
+    - 0 aLightThin _INITIAL
+    - 0          -        -
+    - 5          -        -
+    - 10  aclearcut   _FINAL
+    - 15  aclearcut   _FINAL
+    - 20  aclearcut   _FINAL
+    - 25  aclearcut   _FINAL
+    - '_ACTIVITY report with yields and outputs:'
+    - 'Normalized _ACTIVITY report:'
+    - 'See also:'
+    - _TOTAL
+    - _PERUNITAREA
+    - _NORMALIZE
+    - _AA
+    - _DETAIL
+    used_in:
+    - Reports
+  _AGE:
+    article_id: '806'
+    used_in:
+    - Yields
+    - Actions
+    - Regimes
+    - Transitions
+    - Outputs
+    - Queue
+  _AGECLASS:
+    arguments:
+    - Mask1-2
+    - Interval
+    article_id: '807'
+    syntax:
+    - 'Reports section:'
+    - '*TARGET FileName.EXT'
+    - _AGECLASS [Mask1] Interval
+    - _AGECLASS [Mask2] Interval
+    used_in:
+    - Graphics
+    - Reports
+  _ALAP:
+    article_id: '808'
+    syntax:
+    - '*ACTIONSERIES'
+    - Action1 -> Action2 ->… -> ActionX _ASAP
+    used_in:
+    - Actions
+  _ALL:
+    arguments:
+    - ObjFunction
+    - Interval
+    article_id: '809'
+    syntax:
+    - 'Optimize section:'
+    - '*OBJECTIVE'
+    - ObjFunction - _PENALTY(_ALL) Interval
+    - _GOAL(_ALL)
+    - 'Reports section:'
+    - '*TARGET Filename.Ext [_NORMALIZE]'
+    - _ALL Interval
+    - '_ALL Report drill down feature:'
+    used_in:
+    - Optimize
+    - Reports
+  _APPEND:
+    arguments:
+    - ActionName
+    - Mask1-3
+    - Percent1-2
+    - String
+    - YieldTable
+    article_id: '811'
+    documented_as: _APPEND()
+    syntax:
+    - '*CASE ActionName'
+    - '*SOURCE Mask1'
+    - '*TARGET Mask2 percent1 [_LOCK Number] [_AGE AgeValue]'
+    - '*TARGET Mask3 percent2  [_APPEND(_THx,String or YieldTable)]'
+    used_in:
+    - Transitions
+  _AREA:
+    arguments:
+    - OutputName
+    - Mask
+    - AreaLookup
+    - FileName
+    - EXT
+    - Interval
+    article_id: '812'
+    syntax:
+    - 'Outputs section:'
+    - '*OUTPUT OutputName[_THx] OutputDescription'
+    - '*SOURCE [mask1] [@AGE or @YLD] AreaLookUp _AREA [×, ÷ Constant or TimeYield] + [mask2] [@AGE or
+      @YLD] AreaLookUp _AREA [×, ÷ Constant or TimeYield]'
+    - 'Reports section:'
+    - '*TARGET FileName.EXT'
+    - _AREA Interval
+    used_in:
+    - Outputs
+    - Reports
+  _ARRAY:
+    article_id: '1247'
+    used_in:
+    - '='
+    - '>= Number]  ‘Arrayname’ is a unique'
+    - user-defined array code
+    - upper (<=)
+    - or lower (>=) bound
+  _ASAP:
+    article_id: '813'
+    syntax:
+    - 'Actions section:'
+    - '*ACTIONSERIES'
+    - Action1 -> Action2 ->… -> ActionX _ASAP
+    - 'Regimes section:'
+    - '*SEQUENCES _THX _THY _ASAP'
+    used_in:
+    - Actions
+    - Regimes
+  _AVG:
+    arguments:
+    - OutputName
+    - GraphWindowNumber
+    - ScaleFactor
+    - RHS
+    - Interval
+    - Interval1
+    - FileName
+    - EXT
+    article_id: '814'
+    documented_as: _AVG()
+    syntax:
+    - 'Graphics section:'
+    - '*LINES'
+    - _AVG(OutputName) GraphWindowNumber ScaleFactor SeriesFormat “LegendText”
+    - 'Optimize section:'
+    - '*CONSTRAINTS'
+    - _AVG(OutputName) >=/=/<= RHS Interval
+    - OutputName = _AVG(OutputName,Interval1) Interval
+    - 'Reports section:'
+    - '*TARGET FileName.EXT'
+    - _AVG(OutputName) Interval
+    used_in:
+    - Graphics
+    - Optimize
+    - Reports
+  _BIGM:
+    arguments:
+    - M
+    article_id: '1828'
+    syntax:
+    - '*OUTPUT oOutputName(_THn) Output description'
+    - '*SOURCE _IF(OutputName2,Condition,ValueIfTrue,[ValueIfFalse],[_BIGM = M])'
+    - _BIGM is optional and if not declared
+    - Woodstock
+    used_in:
+    - Outputs
+  _BINARY:
+    arguments:
+    - VarName
+    - ActionName
+    - DefaultAgeReset
+    - ActionDescription
+    - Mask1
+    - OperableCondition
+    - Switch
+    article_id: '1161'
+    syntax:
+    - 'Optimize section:'
+    - '*VARIABLE'
+    - VarName _BINARY
+    - 'Actions section:'
+    - '*ACTION ActionName DefaultAgeReset ActionDescription _BINARY'
+    - '*OPERABLE ActionName'
+    - Mask1 OperableCondition1
+    - 'Regimes section:'
+    - '*REGIME RegimeName RegimeDescription _BINARY'
+    - (...)
+    - 'Control section:'
+    - '*AACONTROL Switch _BINARY'
+    - Woodstock
+    used_in:
+    - Optimize
+    - Actions
+    - Regimes
+    - Control
+  _BINARYARRAY:
+    arguments:
+    - Arrayname
+    article_id: '1236'
+    syntax:
+    - '*VARIABLE'
+    - Arrayname _BINARYARRAY
+    used_in:
+    - Optimize
+  _CAI:
+    arguments:
+    - Mask
+    - NewYieldName
+    - YieldName
+    - YearsPerPeriod
+    article_id: '820'
+    documented_as: _CAI()
+    syntax:
+    - '*YC Mask'
+    - NewYieldName _CAI(YieldName[,YearsPerPeriod])
+    - CAI = (Yield[Ageclass] - Yield[Ageclass-1]) ÷ YearsPerPeriod
+    used_in:
+    - Yields
+  _CAPACITIES:
+    arguments:
+    - MinimumCapacity
+    - MaximumCapacity
+    - HoldoverCapacity
+    article_id: '821'
+    syntax:
+    - _CAPACITIES MinimumCapacity MaximumCapacity HoldoverCapacity [Interval]
+    used_in:
+    - Allocation
+  _CDECL:
+    arguments:
+    - Mask
+    - YieldName
+    - NumParameters
+    - DLLFunction
+    - AgeRange
+    - ScaleFactor
+    - DLLName
+    - DLLParameters
+    article_id: '958'
+    syntax:
+    - 'Fixed Call:'
+    - '*YC Mask'
+    - YieldName _DLL(NumParameters,_CDECL) DLLPath DLLFunction(DLLParameters) (AgeRange) (ScaleFactor)
+    - 'Variant Call:'
+    - '*YC Mask'
+    - YieldName _DLL(CallingProtocol, _CDECL) DLLName DLLFunction(DLLParameters) (AgeRange) (ScaleFactor)
+    - 'Rule(s):'
+    used_in:
+    - Yields
+  _CONDITION:
+    arguments:
+    - FileName
+    - EXT
+    - Interval
+    - OutputNamen
+    article_id: '823'
+    syntax:
+    - '*TARGET FileName.EXT'
+    - _CONDITION Interval
+    - '[OutputName1]'
+    - '[OutputName2]'
+    used_in:
+    - Reports
+  _CONSTRAINTREPORT:
+    article_id: '3088'
+  _CONSTRUCTION:
+    article_id: '3071'
+    used_in:
+    - _VARIABLENAME = vc
+    - _THEME1 = FR
+    - _UPDATESCHEDULE = vc ->aConstr_R
+    - the Woodstock action
+    - to be used for schedule playback
+    - _ISACTIVE = True
+    - _VARIABLENAME = vC
+    - _THEME3 = FR
+    - _ISACTIVE = False
+    - _VARIABLENAME = vB
+    - _THEME3 = BR
+    - there are two construction actions
+    - one for road attribute 'FR'
+    - will be minimized
+  _CP:
+    arguments:
+    - UnitDescription
+    - ActionName
+    - Interval
+    - Mask1-2
+    - OperableCondition
+    - RegimeName
+    - Percent1-2
+    - Mask
+    article_id: '824'
+    syntax:
+    - 'Control section:'
+    - '*PERIODS  UnitDescription'
+    - _CP[1]   Label1
+    - _CP[2]   Label2
+    - _CP[n]   Labeln
+    - 'Actions section:'
+    - '*ACTION ActionName DefaultAgeReset [ActionDescription]'
+    - '*OPERABLE ActionName [_CP Interval]'
+    - Mask1 OperableCondition1
+    - Mask2 OperableCondition2
+    - '*OPERABLE ActionName [_CP Interval]'
+    - Mask1 OperableCondition3
+    - Mask2 OperableCondition4
+    - _CP is a keyword to reference the current planning period,
+    - 'Regimes section:'
+    - '*REGIME RegimeName [RegimeDescription]'
+    - '*OPERABLE RegimeName [_CP Interval]'
+    - Mask1 OperableCondition1
+    - Mask2 OperableCondition2
+    - '*OPERABLE RegimeName [_CP Interval]'
+    - Mask1 OperableCondition3
+    - Mask2 OperableCondition4
+    - 'Transitions section:'
+    - '*CASE ActionName [_CP Interval]'
+    - '*SOURCE mask1'
+    - '*TARGET mask2 percent1'
+    - '*TARGET mask3 percent2'
+    - '*CASE ActionName [_CP Interval]'
+    - '*SOURCE mask1'
+    - '*TARGET mask4 percent1'
+    - '*TARGET mask5 percent2'
+    - 'Yields section:'
+    - '*YT mask'
+    - _CP      YieldName1 YieldName2 YieldName3 ...
+    - Period1    Value1         Value1          Value1
+    - Period2    Value2         Value2          Value2
+    - Period3    Value3         Value3          Value3
+    used_in:
+    - Control
+    - Actions
+    - Regimes
+    - Transitions
+    - Yields
+  _CREATELEVELS:
+    article_id: '3102'
+    syntax:
+    - '*TARGET FileName.ext'
+    - _CREATELEVELS(<numeric:W:D>,<nocomma>,<linelength>)
+    - OutputName1 NewLevelName1 Interval
+    - OutputName1 NewLevelName2 <f(Interval)>
+    - OutputName2 NewLevelName3 Interval
+    - Woodstock
+  _DEATH:
+    article_id: '827'
+    used_in:
+    - Actions
+    - Transitions
+    - Outputs
+    - Schedule
+    - LpSchedule
+    - Reports
+  _DECAY:
+    article_id: '3101'
+  _DEFAULT:
+    article_id: '3061'
+    used_in:
+    - fixed movement cost for the Regime
+    - _DEFAULT = 16500) In this example
+  _DELETE:
+    article_id: '3087'
+    used_in:
+    - OutputName2
+    - ‘EXT’ is the report type (.txt
+    - .dbf
+    - .xlsx
+    - mdb
+    - .htm
+    - .SQLite)
+    - all tables in a .mdb or SQLite database
+  _DELIVER:
+    article_id: '1032'
+    documented_as: About the _DELIVER keyword
+  _DELTA:
+    arguments:
+    - Mask
+    - NewYieldName
+    - YieldName
+    - PeriodicOffset
+    article_id: '829'
+    documented_as: _DELTA()
+    syntax:
+    - '*YC Mask'
+    - NewYieldName _DELTA(YieldName,PeriodicOffset)
+    - 'Rule(s):'
+    used_in:
+    - Yields
+  _DESTINATION:
+    arguments:
+    - TableName
+    - Index1-4
+    - Index1-4Value
+    - TableValue
+    - Enumerator
+    - Expression_Enumerator
+    article_id: '942'
+    syntax:
+    - 'Allocation:'
+    - '*TABLE TableName(_Index1[,_Index2,_Index3,_Index4])'
+    - Index1Value [Index2Value Index3Value Index4Value] TableValue
+    - 'Loops:'
+    - FOREACH Enumerator IN (_DESTINATION)
+    - Expression_Enumerator
+    - ENDFOR
+    used_in:
+    - Allocation
+    - Integrator/FOREACH loops (anywhere)
+  _DETAIL:
+    arguments:
+    - FileName
+    - EXT
+    - Filter
+    - YieldNamen
+    - OutputNamen
+    - Interval
+    - n
+    - d
+    article_id: '1452'
+    syntax:
+    - '*TARGET FileName.EXT'
+    - _DETAIL(Filter)  Interval
+    - '[YieldName1]'
+    - '[YieldName2]'
+    - '[YieldNamen]'
+    - '[OutputName1]'
+    - '[OutputName2]'
+    - '[OutputNamen]'
+    - '*TARGET FileName.EXT'
+    - _DETAIL(aActionName,numeric:n:d)    Interval
+    - (...)
+    used_in:
+    - Reports
+  _DISCOUNTFACTOR:
+    arguments:
+    - Mask
+    - YieldName
+    - YearsPerPeriod
+    article_id: '831'
+    documented_as: _DISCOUNTFACTOR()
+    syntax:
+    - '*YT Mask'
+    - YieldName _DISCOUNTFACTOR(iRate,YearsPerPeriod,Timing)
+    used_in:
+    - Yields
+  _DIVIDE:
+    arguments:
+    - Mask
+    - YieldName
+    article_id: '832'
+    documented_as: _DIVIDE()
+    syntax:
+    - '*YC Mask'
+    - YieldName _DIVIDE(ValueToDivide1,ValueToDivide2)
+    used_in:
+    - Yields
+  _DLL:
+    arguments:
+    - Mask
+    - YieldName
+    - NumParameters
+    - DLLFunction
+    - AgeRange
+    - ScaleFactor
+    - DLLName
+    - DLLParameters
+    article_id: '952'
+    syntax:
+    - 'Fixed Call:'
+    - '*YC Mask'
+    - YieldName _DLL(NumParameters) DLLPath DLLFunction(DLLParameters) (AgeRange) (ScaleFactor)
+    - 'Variant Call:'
+    - '*YC Mask'
+    - YieldName _DLL(CallingProtocol,CallingConvention) DLLName DLLFunction(DLLParameters) (AgeRange)
+      (ScaleFactor)
+    - 'Rule(s):'
+    used_in:
+    - Yields
+  _EACH:
+    arguments:
+    - ThOutputName
+    - SystemConstraint
+    - RHS
+    - DestinationName
+    - ProductName
+    - OriginName
+    - Interval
+    article_id: '835'
+    syntax:
+    - 'Optimize section:'
+    - '*CONSTRAINTS'
+    - ThOutputName(_EACH) >=/=/<= RHS Interval
+    - SystemConstraint(OutputCode(_EACH)) Interval
+    - _DELIVER(DestinationCode,ProductCode,OriginCode) >=/=/<= RHS Interval
+    - _PROCESS(DestinationCode,ProductCode) >=/=/<= RHS Interval
+    - _INVENTORY(DestinationCode,ProductCode) >=/=/<= RHS Interval
+    used_in:
+    - Optimize
+    - Reports
+  _ENDPOINT:
+    arguments:
+    - Mask
+    - YieldName
+    - YieldName1
+    - FirstEndPoint
+    - LastEndPoint
+    article_id: '838'
+    documented_as: _ENDPOINT()
+    syntax:
+    - '*YC Mask'
+    - YieldName _ENDPOINT(YieldName1, FirstEndPoint, YieldName1, LastEndPoint)
+    used_in:
+    - Yields
+  _ENTRY:
+    arguments:
+    - RegimeName
+    - PrescriptionName
+    - ActionName
+    - EntryType
+    - Value
+    article_id: '837'
+    syntax:
+    - '*REGIME RegimeName'
+    - '*PRESCRIPTION PrescriptionName'
+    - '*OPERABLE OperabilityRule1'
+    - OperabilityRule2
+    - '[*TARGET TargetMask1 Percent1'
+    - TargetMask2 Percent2]
+    - _RXPERIOD _ACTION _ENTRY [YieldName]
+    - Period1 ActionName EntryType [Value]
+    - Period2 ActionName EntryType [Value]
+    used_in:
+    - Regimes
+  _EQUALS:
+    arguments:
+    - Output
+    - Period
+    - Value
+    article_id: '1470'
+    syntax:
+    - _EQUALS(Output)[Period] = Value
+  _EQUATION:
+    arguments:
+    - Mask
+    - YieldName
+    - yield
+    - constant
+    article_id: '1317'
+    documented_as: _EQUATION()
+    syntax:
+    - 'Yields section:'
+    - '*YC Mask'
+    - YieldName _EQUATION f(yield,_AGE,thematic index,_THn,constant,LN(),EXP())
+  _EVEN:
+    arguments:
+    - OutputName
+    - Variation
+    article_id: '839'
+    documented_as: _EVEN()
+    syntax:
+    - '*CONSTRAINTS'
+    - _EVEN(OutputName[,Variation])  Interval
+    - _GOAL may not be used with the _EVEN constraint.
+    - '_EVEN() can be written using three separate constraints to utilize _GOAL():'
+    - '*CONSTRAINTS'
+    - OutputName >= LowerBound  Interval _GOAL
+    - OutputName <= UpperBound  Interval
+    - (1-(variation/100)) * UpperBound - LowerBound <= 0  1..1
+    used_in:
+    - Optimize
+  _FINAL:
+    arguments:
+    - ActionName
+    - EntryType
+    - YieldName
+    - Value
+    article_id: '843'
+    syntax:
+    - _RXPERIOD   _ACTION      _ENTRY     YieldName
+    - Period1      ActionName   EntryType      Value
+    - Period2      ActionName   EntryType      Value
+    used_in:
+    - Regimes
+  _FIRSTDATE:
+    article_id: '3060'
+    used_in:
+    - 2026-12-01) or a Character string (e.g.
+    - “Frozen2026”
+  _FIXEDCOST:
+    article_id: '3037'
+    used_in:
+    - _DEFAULT = 165000) In this example
+  _FORM2:
+    arguments:
+    - FileName
+    - EXT
+    - OutputName1-2
+    - f
+    - Interval
+    article_id: '844'
+    syntax:
+    - '*TARGET FileName.EXT [_FORM2]'
+    - OutputName1 Interval
+    - OutputName2 Interval
+    used_in:
+    - Reports
+  _FORMFEED:
+    arguments:
+    - FileName
+    - EXT
+    - OutputName1-2
+    - f
+    - Interval
+    article_id: '845'
+    syntax:
+    - '*TARGET FileName.EXT [_FORM2]'
+    - OutputName1 Interval
+    - OutputName2 Interval
+    - _FORMFEED Interval
+    used_in:
+    - Reports
+  _GOAL:
+    arguments:
+    - Constraint3
+    - RHS
+    - Interval
+    - OverPenalty
+    - UnderPenalty
+    article_id: '847'
+    syntax:
+    - 'Optimize section:'
+    - '*OBJECTIVE'
+    - _GOAL(GoalName1,GoalName2,GoalName3…)
+    - '*CONSTRAINTS'
+    - Constraint1 >= RHS Interval  _GOAL(GoalName1,UnderPenalty)
+    - Constraint2 <= RHS Interval  _GOAL(GoalName2,OverPenalty)
+    - Constraint3   = RHS Interval  _GOAL(GoalName3,OverPenalty,UnderPenalty)
+    - 'Allocation section:'
+    - Constraint1 >= RHS Interval _GOAL(GoalName1,UnderPenalty)
+    - Constraint2 <= RHS Interval _GOAL(GoalName2,OverPenalty)
+    - Constraint3 = RHS Interval _GOAL(GoalName3,OverPenalty,UnderPenalty)
+    - Integrator
+    used_in:
+    - Optimize
+    - Allocation
+  _GREENUPCONSTRAINTS:
+    article_id: '1467'
+    documented_as: _GREENUPCONSTRAINTS()
+  _IF:
+    arguments:
+    - YieldName
+    - ValueIfTrue
+    - ValueIfFalse
+    - M
+    article_id: '1465'
+    syntax:
+    - 'Yields Section:'
+    - '*YC mask'
+    - YieldName _IF(YieldCondition,ValueIfTrue,ValueIfFalse)
+    - 'Outputs Section:'
+    - '*OUTPUT oOutputName(_THn) Output description'
+    - '*SOURCE _IF(OutputName2,Condition,ValueIfTrue,[ValueIfFalse],[_BIGM = M])'
+    - Woodstock
+    used_in:
+    - Yields
+    - Outputs
+  _IGNOREIF:
+    article_id: '1762'
+  _INDEX:
+    arguments:
+    - BasicCode
+    - Value
+    article_id: '850'
+    syntax:
+    - '*THEME [Description]'
+    - BasicCode [Description] _INDEX(IndexCode1=Value,IndexCode2=Value,…)
+    - 'Examples of general formulation:'
+    - ; Landscape
+    - '*THEME species'
+    - ; Yields
+    - '*YC ? ? ?'
+    - ; Landscape
+    - '*THEME Block id'
+    - S103 _INDEX(hc=27.54)
+    - S11 _INDEX(hc=29.27)
+    - S110 _INDEX(hc=25.00)
+    - S12 _INDEX(hc=29.71)
+    - ; Yields
+    - '*YC ? ? ?'
+    used_in:
+    - Landscape
+  _INFLATIONFACTOR:
+    arguments:
+    - Mask
+    - YearsPerPeriod
+    article_id: '949'
+    syntax:
+    - '*YT Mask'
+    - YieldName _INFLATIONFACTOR(iRate,YearsPerPeriod,Timing)
+    - Woodstock
+    used_in:
+    - Yields
+  _INITIAL:
+    arguments:
+    - RegimeName
+    - PrescriptionName
+    - ActionName
+    - EntryType
+    - Value
+    article_id: '851'
+    syntax:
+    - '*REGIME RegimeName'
+    - '*PRESCRIPTION PrescriptionName'
+    - '*OPERABLE OperabilityRule1'
+    - OperabilityRule2
+    - '[*TARGET TargetMask1 Percent1'
+    - TargetMask2 Percent2]
+    - _RXPERIOD _ACTION _ENTRY [YieldName]
+    - Period1 ActionName EntryType [Value]
+    - Period2 ActionName EntryType [Value]
+    used_in:
+    - Regimes
+  _INPROGRESS:
+    arguments:
+    - Mask
+    - Age
+    - Area
+    - PrescriptionName
+    - RXPeriod
+    - FinalEntryPeriod
+    article_id: '755'
+    syntax:
+    - Mask age area _INPROGRESS(PrescriptionName,RXPeriod,[FinalEntryPeriod])
+    used_in:
+    - LPSchedule
+  _INPUTS:
+    arguments:
+    - DestinationName
+    - AbsMin
+    - AbsMax
+    article_id: '852'
+    syntax:
+    - '*DESTINATION DestinationName'
+    - _INPUTS ProductName1 AbsMin AbsMax %Min %Max
+    - ProductName2 AbsMin AbsMax %Min %Max
+    used_in:
+    - Allocation
+  _INTEGER:
+    arguments:
+    - Number
+    - ActionName
+    - DefaultAgeReset
+    - ActionDescription
+    - Mask1
+    - OperableCondition
+    article_id: '853'
+    syntax:
+    - 'Optimize section:'
+    - '*VARIABLE'
+    - VariableCode1
+    - VariableCode2 _INTEGER [<=/>= Number]
+    - 'Actions section:'
+    - '*ACTION ActionName DefaultAgeReset ActionDescription _INTEGER'
+    - '*OPERABLE ActionName'
+    - Mask1 OperableCondition1
+    - 'Regimes section:'
+    - '*REGIME RegimeName RegimeDescription _INTEGER'
+    used_in:
+    - Optimize
+    - Actions
+    - Regimes
+  _INTEGERARRAY:
+    arguments:
+    - Arrayname
+    - NaturalNumber
+    article_id: '1235'
+    syntax:
+    - '*VARIABLE'
+    - Arrayname  _INTEGERARRAY [ <=, = , >=  NaturalNumber]
+    used_in:
+    - Optimize
+  _INTERVAL:
+    article_id: '1749'
+    used_in:
+    - maximum will be tested
+  _INVALIDORIGINS:
+    arguments:
+    - DestinationName
+    - AbsMin
+    - AbsMax
+    article_id: '854'
+    syntax:
+    - '*DESTINATION DestinationName'
+    - _INPUTS ProductName1 AbsMin AbsMax %Min %Max
+    - ProductName2 AbsMin AbsMax %Min %Max
+    - _INVALIDORIGINS OriginCode1,OriginCode2,…
+    used_in:
+    - Allocation
+  _INVENT:
+    article_id: '855'
+    syntax:
+    - 'Standing inventory:'
+    - '*OUTPUT OutputName[_THx] OutputDescription'
+    - '*SOURCE [Mask1] [@AGE or @YLD] _INVENT ValueToSum +'
+    - '[Mask2] [@AGE or @YLD] _INVENT ValueToSum'
+    - Or
+    - 'Operable inventory:'
+    - '*OUTPUT OutputName[_THx] OutputDescription'
+    - '*SOURCE [Mask1] [@AGE or @YLD] _INVENT(ActionCode1,ActionCode2,…) ValueToSum +'
+    - '[Mask2] [@AGE or @YLD] _INVENT(ActionCode1,ActionCode2,…) ValueToSum'
+    used_in:
+    - Outputs
+  _INVENTORY:
+    article_id: '1034'
+    documented_as: About the _INVENTORY keyword
+  _INVLOCK:
+    arguments:
+    - OutputName
+    - Mask1-2
+    - ValueToSum
+    article_id: '857'
+    syntax:
+    - '*OUTPUT OutputName[_THx] OutputDescription'
+    - '*SOURCE [Mask1] [@AGE or @YLD] _INVLOCK ValueToSum +'
+    - '[Mask2] [@AGE or @YLD] _INVLOCK ValueToSum'
+    used_in:
+    - Outputs
+  _IRR:
+    arguments:
+    - MyRevenueOutput
+    - MyCostOutput
+    - ConstantCapitalInvestment
+    article_id: '1485'
+    syntax:
+    - '*OUTPUT OutputName Output Description'
+    - '*SOURCE _IRR(MyRevenueOutput,MyCostOutput,[ConstantCapitalInvestment],[%])'
+    - 'Rule(s):'
+    used_in:
+    - Outputs
+  _KEEPAASGOING:
+    article_id: '1827'
+  _LENGTH:
+    article_id: '860'
+    syntax:
+    - FirstPeriod..LastPeriod
+    used_in:
+    - Areas
+    - Actions
+    - Transitions
+    - Queue
+    - Optimize
+    - Reports
+    - Allocation
+  _LOCK:
+    arguments:
+    - mask
+    - age
+    - AreaValue
+    - aacode
+    - Number
+    - ActionName
+    - Percent1
+    - Percent
+    article_id: '862'
+    syntax:
+    - 'Areas section:'
+    - '*A mask Age AreaValue _LOCK Number'
+    - '*AA mask Age AreaValue aacode _LOCK Number'
+    - 'Transitions section:'
+    - '*CASE ActionName'
+    - '*SOURCE Mask1'
+    - '*TARGET Mask2 percent1 _LOCK Number'
+    - 'Regimes sections:'
+    - '*PRESCRIPTION PrescriptionName'
+    - '*TARGET Mask percent _LOCK Number'
+    used_in:
+    - Areas
+    - Transitions
+    - Regimes
+  _LOCKEXEMPT:
+    arguments:
+    - ActionName
+    - DefaultAgeReset
+    - ActionDescription
+    article_id: '864'
+    syntax:
+    - '*ACTION ActionName DefaultAgeReset _LOCKEXEMPT [ActionDescription]'
+    - '*OPERABLE ActionName'
+    - Mask1 OperableCondition1
+    - Mask2 OperableCondition2
+    - Maskn OperableConditionn
+    used_in:
+    - Actions
+  _LOWERLIMIT:
+    arguments:
+    - Output
+    - Period
+    - Value
+    - GraphWindowNumber
+    - ScaleFactor
+    article_id: '1471'
+    syntax:
+    - 'Schedule section:'
+    - _LOWERLIMIT(Output)[Period] = Value
+    - 'Graphics section:'
+    - _LOWERLIMIT(Output) GraphWindowNumber ScaleFactor SeriesFormat "LegendText"
+  _MAI:
+    arguments:
+    - Mask
+    - NewYieldName
+    - YieldName
+    - YearsPerPeriod
+    article_id: '863'
+    documented_as: _MAI()
+    syntax:
+    - '*YC mask'
+    - NewYieldName _MAI(YieldName[,YearsPerPeriod])
+    - MAI = Yield / Ageclass / YearsPerPeriod
+    used_in:
+    - Yields
+  _MAINTENANCE:
+    article_id: '1803'
+    documented_as: _MAINTENANCE()
+    used_in:
+    - Reports
+  _MAX:
+    arguments:
+    - FileName
+    - EXT
+    - OutputName
+    - Interval
+    - GraphWindowNumber
+    - ScaleFactor
+    - Value
+    - Mask
+    - ActionName1-2
+    - Percent
+    - ActionName
+    - ObjectiveSense
+    - Constant
+    article_id: '867'
+    syntax:
+    - 'Reports section:'
+    - '*TARGET FileName.EXT [_FORM2] [_RESET n]'
+    - _MAX(OutputName) Interval
+    - 'Graphics section:'
+    - '*LINES'
+    - _MAX(OutputName) GraphWindowNumber ScaleFactor SeriesFormat “LegendText”
+    - _MIN(OutputName) GraphWindowNumber ScaleFactor SeriesFormat “LegendText”
+    - 'Queue section:'
+    - '*TARGET OutputName =,<=,>= Value Interval [_MAX]'
+    - '*SOURCE [Mask] ActionName1 Percent'
+    - '*SOURCE [Mask] ActionName2 Percent'
+    - '*SELECT ActionName'
+    - _MAX _AGE or YieldName
+    - _MIN _AGE or YieldName
+    - …
+    - 'Optimize section:'
+    - '*OBJECTIVE'
+    - ObjectiveSense f(Output1,Output2,..[Constant] * OutputX) Interval
+    - 'Yields section:'
+    - '*YC [Mask]'
+    - YieldName1 _MAX(YieldName,Value)
+    - YieldName2 _MAX(YieldName,...,YieldNameN)
+    used_in:
+    - Reports
+    - Graphics
+    - Queue
+    - Optimize
+    - Yields
+  _MAXAGE:
+    article_id: '868'
+  _MAXDELTA:
+    arguments:
+    - ActionName
+    - YieldName
+    - Offset
+    article_id: '869'
+    syntax:
+    - '*SELECT ActionName'
+    - _MAXDELTA YieldName Offset
+    - …
+    used_in:
+    - Queue
+  _MAXMIN:
+    arguments:
+    - Interval
+    - Constant
+    article_id: '870'
+    syntax:
+    - '*OBJECTIVE'
+    - _MAXMIN f(Output1,Output2,..[Constant] * OutputX) Interval
+    used_in:
+    - Optimize
+  _MIN:
+    arguments:
+    - FileName
+    - EXT
+    - OutputName
+    - Interval
+    - GraphWindowNumber
+    - ScaleFactor
+    - Value
+    - Mask
+    - ActionName1-2
+    - Percent
+    - ActionName
+    - ObjectiveSense
+    - Constant
+    article_id: '872'
+    syntax:
+    - 'Reports section:'
+    - '*TARGET FileName.EXT [_FORM2] [_RESET n]'
+    - _MIN(OutputName) Interval
+    - 'Graphics section:'
+    - '*LINES'
+    - _MIN(OutputName) GraphWindowNumber ScaleFactor SeriesFormat “LegendText”
+    - _MAX(OutputName) GraphWindowNumber ScaleFactor SeriesFormat “LegendText”
+    - 'Queue section:'
+    - '*TARGET OutputName =,<=,>= Value Interval [_MIN]'
+    - '*SOURCE [Mask] ActionName1 Percent'
+    - '*SOURCE [Mask] ActionName2 Percent'
+    - '*SELECT ActionName'
+    - _MIN _AGE or YieldName
+    - _MAX _AGE or YieldName
+    - …
+    - 'Optimize section:'
+    - '*OBJECTIVE'
+    - ObjectiveSense f(Output1,Output2,..[Constant] * OutputX) Interval
+    - 'Yields section:'
+    - '*YC [Mask]'
+    - YieldName1 _MIN(YieldName,Value)
+    - YieldName2 _MIN(YieldName,...,YieldNameN)
+    used_in:
+    - Reports
+    - Graphics
+    - Queue
+    - Optimize
+    - Yields
+  _MINDELTA:
+    arguments:
+    - ActionName
+    - YieldName
+    - Offset
+    article_id: '873'
+    syntax:
+    - '*SELECT ActionName'
+    - _MINDELTA YieldName Offset
+    - …
+    used_in:
+    - Queue
+  _MINMAX:
+    arguments:
+    - Interval
+    - Constant
+    article_id: '874'
+    syntax:
+    - '*OBJECTIVE'
+    - _MAXMIN f(Output1,Output2,..[Constant] * OutputX) Interval
+    - _MINMAX is not a commonly-used objective function.
+    used_in:
+    - Optimize
+  _MULTIPLY:
+    arguments:
+    - Mask
+    - YieldName
+    article_id: '875'
+    documented_as: _MULTIPLY()
+    syntax:
+    - '*YC Mask'
+    - YieldName _MULTIPLY(ValueToMultiply1,ValueToMultiply2,…)
+    used_in:
+    - Yields
+  _NA:
+    arguments:
+    - mask
+    - age
+    - AreaValue
+    - aacode
+    - Interval
+    article_id: '877'
+    syntax:
+    - '*A mask age AreaValue _NA Interval'
+    - '*AA mask age AreaValue aacode _NA Interval'
+    - Rules
+    used_in:
+    - Areas
+  _NDY:
+    arguments:
+    - OutputName
+    article_id: '878'
+    documented_as: _NDY()
+    syntax:
+    - '*CONSTRAINTS'
+    - _NDY(OutputName)  Interval
+    used_in:
+    - Optimize
+  _NEGDELTA:
+    arguments:
+    - Mask
+    - NewYieldName
+    - YieldName
+    - PeriodicOffset
+    article_id: '879'
+    documented_as: _NEGDELTA()
+    syntax:
+    - '*YC Mask'
+    - NewYieldName _NEGDELTA(YieldName,PeriodicOffset)
+    - 'Rule(s):'
+    used_in:
+    - Yields
+  _NORMALIZE:
+    article_id: '1816'
+    used_in:
+    - …
+    - xlsx
+    - '*'
+    - Forest)
+    - '*'
+    - Forest)
+    - '*'
+    - Forest)
+    - '*'
+    - Forest)
+    - '*'
+    - Forest)
+    - '*'
+    - Forest)
+    - joinID for the first five rows
+    - then the next
+    - so on.  Also note the outputnames
+  _OPERABLE:
+    arguments:
+    - FileName
+    - EXT
+    - Interval
+    article_id: '881'
+    documented_as: _OPERABLE()
+    syntax:
+    - '*TARGET FileName.EXT'
+    - _OPERABLE([ActionName1,ActionName2,…]) Interval
+    used_in:
+    - Reports
+  _ORIGIN:
+    arguments:
+    - TableName
+    - Index1-4
+    - Index1-4Value
+    - TableValue
+    article_id: '884'
+    syntax:
+    - '*TABLE TableName(_Index1[,_Index2,_Index3,_Index4])'
+    - Index1Value [Index2Value Index3Value Index4Value] TableValue
+    used_in:
+    - Allocation
+  _OUTPUTS:
+    arguments:
+    - DestinationName
+    - Description
+    - Factor
+    article_id: '885'
+    syntax:
+    - 'Allocation Section:'
+    - '*DESTINATION DestinationName Description'
+    - _OUTPUTS ResidualProductName1 <- Factor ProductName1
+    - ResidualProductName2 <- Factor ProductName2
+    - 'Integrator :'
+    - Foreach xx in (_OUTPUTS)
+    - Endfor
+    used_in:
+    - Allocation
+    - Integrator/FOREACH  loops (anywhere)
+  _OVERRIDE:
+    article_id: '1476'
+  _PEAKMAI:
+    arguments:
+    - Mask
+    - NewYieldName
+    - YieldName
+    - YearsPerPeriod
+    article_id: '887'
+    documented_as: _PEAKMAI()
+    syntax:
+    - '*YC Mask'
+    - NewYieldName  _PEAKMAI(YieldName[,YearsPerPeriod])
+    - 'Rule(s):'
+    used_in:
+    - Yields
+  _PENALTY:
+    arguments:
+    - ObjectiveSense
+    - Function
+    - Interval
+    article_id: '888'
+    documented_as: _PENALTY()
+    syntax:
+    - '*OBJECTIVE'
+    - ObjectiveSense Function - _PENALTY(GoalsToPenalize) Interval
+    - Woodstock
+    - Allocation Optimizer
+    used_in:
+    - Optimize
+  _PERIOD:
+    arguments:
+    - TableName
+    - Index1-4
+    - Index1-4Value
+    - TableValue
+    article_id: '889'
+    syntax:
+    - '*TABLE TableName(_Index1[,_Index2,_Index3,_Index4])'
+    - Index1Value [Index2Value Index3Value Index4Value] TableValue
+    used_in:
+    - Allocation
+  _PERUNITAREA:
+    arguments:
+    - FileName
+    - EXT
+    - SystemReport
+    - Interval
+    - OutputName
+    article_id: '1483'
+    syntax:
+    - '*TARGET FileName.EXT'
+    - SystemReport Interval
+    - _TOTAL
+    - OutputName1
+    - OutputName2
+    - _PERUNITAREA
+    - OutputName1
+    - OutputName2
+    - _AA
+    - _ACTIVITY
+    - _CONDITION
+    - _DETAIL
+  _POSDELTA:
+    arguments:
+    - Mask
+    - NewYieldName
+    - YieldName
+    - PeriodicOffset
+    article_id: '891'
+    documented_as: _POSDELTA()
+    syntax:
+    - '*YC Mask'
+    - NewYieldName _POSDELTA(YieldName,PeriodicOffset)
+    - 'Rule(s):'
+    used_in:
+    - Yields
+  _PROCESS:
+    article_id: '1033'
+    documented_as: About the _PROCESS keyword
+  _PRODUCT:
+    arguments:
+    - TableName
+    - Index1-4
+    - Index1-4Value
+    - TableValue
+    - Enumerator
+    - Expression_Enumerator
+    article_id: '893'
+    syntax:
+    - 'Allocation section:'
+    - '*TABLE TableName(_Index1[,_Index2,_Index3,_Index4])'
+    - Index1Value [Index2Value Index3Value Index4Value] TableValue
+    - 'FOREACH loops:'
+    - FOREACH Enumerator IN (_PRODUCT)
+    - Expression_Enumerator
+    - ENDFOR
+    used_in:
+    - Allocation
+    - Integrator/FOREACH loops (anywhere)
+  _PRODUCTIONRATE:
+    article_id: '3040'
+    used_in:
+    - ScaleFactor
+    - harvest unit.  Note that
+    - yScaleFactor
+    - _PRODUCTIONRATE points to the yProdRate
+  _PROPERTIES:
+    arguments:
+    - FileName
+    - EXT
+    - PropertyName
+    - Reportcontent
+    article_id: '3009'
+    syntax:
+    - '*TARGET FileName.EXT _PROPERTIES(PropertyName1[,PropertyName2,...,PropertyNameN])'
+    - Reportcontent
+    - Rules
+  _RANDOM:
+    arguments:
+    - ActionName
+    - Mask
+    - Percent
+    - EventArea
+    - ProbabilityYield
+    - Enumerator
+    - Expression_Enumerator
+    article_id: '895'
+    syntax:
+    - 'Transitions section:'
+    - '*CASE ActionName _RANDOM EventArea'
+    - '*SOURCE Mask'
+    - '*TARGET Mask Percent'
+    - 'Queue section:'
+    - '*SELECT ActionName'
+    - _RANDOM
+    - '*AVAILABLE ActionName'
+    - Mask ProbabilityYield EventArea
+    - 'FOREACH:'
+    - FOREACH Enumertor IN _RANDOM(NumberOfDraws,[MinValue],MaxValue)
+    - Expression_Enumerator
+    - ENDFOR
+    - 'Rule(s):'
+    used_in:
+    - Transitions
+    - Queue
+    - All (FOREACH only)
+  _RANGE:
+    arguments:
+    - Mask
+    - YieldName
+    - FirstValue
+    - LastValue
+    article_id: '950'
+    syntax:
+    - '*YC Mask'
+    - YieldName _RANGE(YieldName1,FirstValue,LastValue,YieldName2,FirstValue,LastValue,…)
+    - 'Rule(s):'
+    used_in:
+    - Yields
+  _REGISTER:
+    arguments:
+    - Mask
+    - YieldName
+    - NumParameters
+    - DLLFunction
+    - AgeRange
+    - ScaleFactor
+    - DLLName
+    - DLLParameters
+    article_id: '954'
+    syntax:
+    - 'Fixed Call:'
+    - '*YC Mask'
+    - YieldName _DLL(NumParameters,_REGISTER) DLLPath DLLFunction(DLLParameters) (AgeRange) (ScaleFactor)
+    - 'Variant Call:'
+    - '*YC Mask'
+    - YieldName _DLL(CallingProtocol, _REGISTER) DLLName DLLFunction(DLLParameters) (AgeRange) (ScaleFactor)
+    - 'Rule(s):'
+    used_in:
+    - Yields
+  _REPLACE:
+    arguments:
+    - ActionName
+    - Mask
+    - Percent
+    - String
+    - YieldTable
+    article_id: '896'
+    documented_as: _REPLACE()
+    syntax:
+    - '*CASE ActionName'
+    - '*SOURCE Mask'
+    - '*TARGET Mask Percent _REPLACE(_THn, String or YieldTable)'
+    - '*TARGET Mask Percent _REPLACE(_THn, String or YieldTable, THn, String or YieldTable, THn, String
+      or YieldTable, ... )'
+    used_in:
+    - Transitions
+  _RESET:
+    arguments:
+    - FileName
+    - OutputName
+    - Interval
+    article_id: '897'
+    syntax:
+    - '*TARGET FileName.TXT'
+    - OutputName Interval
+    - 'Rule(s):'
+    used_in:
+    - Reports
+  _RX:
+    arguments:
+    - Mask
+    - Age
+    - Area
+    - RegimeName
+    - Period
+    - Condition
+    - PrescriptionName
+    - FinalEntryPeriod
+    article_id: '754'
+    syntax:
+    - 'Schedule section:'
+    - Mask Age Area RegimeName Period Condition _RX(PrescriptionName,FinalEntryPeriod)
+    - _RX is a keyword to indicate the prescription to schedule,
+    - 'LPSchedule section:'
+    - Mask Age Area RegimeName Period _RX(PrescriptionName,[FinalEntryPeriod])
+    - _RX is a keyword to indicate the prescription to schedule,
+    used_in:
+    - Schedule
+    - LPSchedule
+  _RXPERIOD:
+    arguments:
+    - RegimeName
+    - PrescriptionName
+    - Interval
+    - Mask
+    - OperableCondition
+    article_id: '1233'
+    syntax:
+    - '*REGIME RegimeName'
+    - '*OPERABLE RegimeName [_CP Interval]'
+    - Mask OperableCondition
+    - '*PRESCRIPTION PrescriptionName'
+    - _RXPERIOD _ACTION _ENTRY Yield1 Yield2 …
+    - _CP is a keyword to reference the current planning period,
+    used_in:
+    - Regimes
+  _SAMEAS:
+    arguments:
+    - DefaultAgeReset
+    - ActionDescription
+    - Mask1-X
+    - OperableCondition
+    article_id: '899'
+    syntax:
+    - 'In Actions section (with operable declaration):'
+    - '*ACTION ActionName DefaultAgeReset ActionDescription'
+    - '*OPERABLE ActionName _SAMEAS OtherActionName'
+    - 'In Actions section (with partial declaration):'
+    - '*ACTION ActionName DefaultAgeReset [ActionDescription]'
+    - '*OPERABLE ActionName'
+    - Mask1 OperableCondition1
+    - Mask2 OperableCondition2
+    - Maskn OperableConditionn
+    - '*PARTIAL ActionName    _SAMEAS OtherPartialActionName'
+    - 'In Transitions section:'
+    - '*CASE ActionName _SAMEAS OtherActionName'
+    used_in:
+    - Actions
+    - Transitions
+  _SCALEBY:
+    arguments:
+    - YieldType
+    - Mask
+    - YieldName
+    - DLLCall
+    - ScaleFactor
+    article_id: '900'
+    syntax:
+    - YieldType Mask
+    - YieldName DLLCall _SCALEBY ScaleFactor
+    used_in:
+    - Yields
+  _SCHEDULE:
+    arguments:
+    - FileName
+    - EXT
+    - Interval
+    article_id: '902'
+    documented_as: _SCHEDULE()
+    syntax:
+    - '*TARGET FileName.EXT'
+    - _SCHEDULE([ActionName1,ActionName2,…]) Interval
+    - 'Rule(s):'
+    used_in:
+    - Reports
+  _SELECT:
+    arguments:
+    - FileName
+    - EXT
+    - ActionName
+    - Interval
+    article_id: '903'
+    documented_as: _SELECT()
+    syntax:
+    - '*TARGET FileName.EXT'
+    - _SELECT(ActionName) Interval
+    used_in:
+    - Reports
+  _SEQ:
+    arguments:
+    - OutputName
+    - PercentIncrease
+    - PercentDecrease
+    article_id: '904'
+    documented_as: _SEQ()
+    syntax:
+    - _SEQ(OutputName,PercentIncrease,PercentDecrease)
+    used_in:
+    - Optimize
+  _SHIFT:
+    arguments:
+    - Mask
+    - NewYieldName
+    - YieldName
+    - PeriodstoShift
+    article_id: '905'
+    documented_as: _SHIFT()
+    syntax:
+    - '*YC Mask'
+    - NewYieldName  _SHIFT(YieldName,PeriodstoShift)
+    used_in:
+    - Yields
+  _STDCALL:
+    arguments:
+    - Mask
+    - YieldName
+    - NumParameters
+    - DLLFunction
+    - AgeRange
+    - ScaleFactor
+    - DLLName
+    - DLLParameters
+    article_id: '957'
+    syntax:
+    - 'Fixed Call:'
+    - '*YC Mask'
+    - YieldName _DLL(NumParameters,_STDCALL) DLLPath DLLFunction(DLLParameters) (AgeRange) (ScaleFactor)
+    - 'Variant Call:'
+    - '*YC Mask'
+    - YieldName _DLL(CallingProtocol, _STDCALL) DLLName DLLFunction(DLLParameters) (AgeRange) (ScaleFactor)
+    - 'Rule(s):'
+    used_in:
+    - Yields
+  _STEP:
+    arguments:
+    - AmountIncrease
+    - AmountDecrease
+    article_id: '911'
+    documented_as: _STEP()
+    syntax:
+    - _STEP(OutputName,AmountIncrease,AmountDecrease)
+    used_in:
+    - Optimize
+  _SUBSTR:
+    article_id: '1745'
+  _SUBTRACT:
+    arguments:
+    - Mask
+    - YieldName
+    article_id: '1327'
+    documented_as: _SUBTRACT()
+    syntax:
+    - '*YC Mask'
+    - YieldName _SUBTRACT(ValueToSubtract1,ValueToSubtract2)
+    used_in:
+    - Yields
+  _SUM:
+    arguments:
+    - Mask
+    - YieldName
+    - OutputName
+    - FileName
+    - EXT
+    - Interval
+    - VariableName
+    - Interval1
+    - RHS
+    article_id: '912'
+    documented_as: _SUM()
+    syntax:
+    - 'Yields Section:'
+    - '*YC Mask'
+    - YieldName _SUM(ValuetoSum1,ValuetoSum2,...)
+    - 'Graphics Section:'
+    - _SUM(OutputName)«Window and Series Properties»
+    - 'Reports Section:'
+    - '*TARGET FileName.EXT'
+    - _SUM(OutputName) Interval
+    - 'Optimize Section:'
+    - VariableName - _SUM(OutputName) = 0 Interval
+    - _SUM(OutputName,Interval1) = RHS Interval
+    used_in:
+    - Yields
+    - Graphics
+    - Reports
+    - Optimize
+  _TH:
+    arguments:
+    - OutputName
+    - OutputDescription
+    - Mask
+    - AreaLookup
+    - ValueToSum
+    - ActionName
+    - Percent
+    - String
+    - Enumerator
+    - Expression_Enumerator
+    article_id: '913'
+    documented_as: _THn
+    syntax:
+    - 'Outputs section:'
+    - '*OUTPUT OutputName(_THn) OutputDescription'
+    - '*SOURCE Mask [@AGE or @YLD] AreaLookUp ValueToSum'
+    - 'Transitions section:'
+    - '*CASE ActionName'
+    - '*SOURCE Mask'
+    - '*TARGET Mask Percent _REPLACE(_THn, String)'
+    - 'Yields section:'
+    - 'FOREACH:'
+    - FOREACH Enumerator IN (_THn)
+    - Expression_Enumerator
+    - ENDFOR
+    - 'Rule(s):'
+    used_in:
+    - Outputs
+    - Transitions
+    - Yields
+    - FOREACH loops
+  _THEMEn:
+    article_id: '943'
+    syntax:
+    - '*ORIGIN _THEMEn'
+    used_in:
+    - Allocation
+  _TOTAL:
+    arguments:
+    - FileName
+    - EXT
+    - SystemReport
+    - Interval
+    - OutputName
+    article_id: '1482'
+    syntax:
+    - '*TARGET FileName.EXT'
+    - SystemReport Interval
+    - _TOTAL
+    - OutputName1
+    - OutputName2
+    - OutputName3
+    - _AA
+    - _ACTIVITY
+    - _CONDITION
+    - _DETAIL
+  _TRACE:
+    arguments:
+    - Tag
+    article_id: '914'
+    syntax:
+    - '*CASE ActionName'
+    - '*SOURCE Mask1  _TRACE(Tag)'
+    - '*TARGET  Mask2  Percent'
+    - 'Rule(s):'
+    - •
+    - Woodstock
+    used_in:
+    - Transitions
+  _TSLA:
+    arguments:
+    - Mask
+    - Operator
+    - RHS
+    article_id: '1488'
+    syntax:
+    - '*ACTION ActionName DefaultAgeReset [ActionDescription]'
+    - '*OPERABLE ActionName [_CP Interval]'
+    - Mask _TSLA operator RHS
+    used_in:
+    - Actions
+  _UPPERLIMIT:
+    arguments:
+    - Output
+    - Period
+    - Value
+    - GraphWindowNumber
+    - ScaleFactor
+    article_id: '1472'
+    syntax:
+    - 'Schedule section:'
+    - _UPPERLIMIT(Output)[Period] = Value
+    - 'Graphics section:'
+    - _UPPERLIMIT(Output) GraphWindowNumber ScaleFactor SeriesFormat "LegendText"
+  _VARIABLE:
+    article_id: '1806'
+  _VARIANT:
+    arguments:
+    - Mask
+    - YieldName
+    - DLLName
+    - DLLFunction
+    - DLLParameters
+    - AgeRange
+    - ScaleFactor
+    article_id: '955'
+    syntax:
+    - 'Variant Call:'
+    - '*YC Mask'
+    - YieldName _DLL(CallingProtocol,CallingConvention) DLLName DLLFunction(DLLParameters) (AgeRange)
+      (ScaleFactor)
+    - 'Rule(s):'
+    used_in:
+    - Yields
+  _VIEW:
+    arguments:
+    - Mask
+    - Yieldn
+    article_id: '1234'
+    syntax:
+    - '*Y Mask _VIEW'
+    - _AGE Yield1 Yield2
+    used_in:
+    - Yields
+  _YIELD:
+    arguments:
+    - FileName
+    - EXT
+    - Filter
+    - Period
+    - YieldName
+    article_id: '920'
+    syntax:
+    - 'Reports:'
+    - '*TARGET FileName.EXT'
+    - _YIELD[(Filter)] Period
+    - '[YieldName]'
+    used_in:
+    - Reports
+    - Integrator /FOREACH loops (anywhere)
+  _YTP:
+    arguments:
+    - Mask
+    - YieldName
+    article_id: '921'
+    documented_as: _YTP()
+    syntax:
+    - '*YC Mask'
+    - YieldName  _YTP(YieldName)
+    - 'Rule(s):'
+    used_in:
+    - Yields
+meta:
+  description: 'Keyword contract for the Woodstock model input data format: which section each keyword
+    belongs to, its syntax skeleton, and its argument names.'
+  keyword_count: 198
+  name: woodstock-input-format-contract
+  note: This file describes the Woodstock format. Which parts of it ws3 reads is recorded in ws3.woodstock,
+    alongside the importers that provide it.
+  provenance: Keyword names, section scoping and syntax skeletons derived from the vendor documentation.
+    Interface facts only -- no vendor prose is reproduced here. Descriptive text remains in the private
+    reference repository.
+  sections:
+    Actions:
+      file_extension: act
+    Allocation:
+      file_extension: alloc
+    Areas:
+      file_extension: are
+    Constants:
+      file_extension: con
+    Control:
+      file_extension: run
+    Graphics:
+      file_extension: gra
+    Landscape:
+      file_extension: lan
+    Lifespan:
+      file_extension: lif
+    LpSchedule:
+      file_extension: lps
+    Optimize:
+      file_extension: opt
+    Outputs:
+      file_extension: out
+    Queue:
+      file_extension: que
+    Regimes:
+      file_extension: rgm
+    Reports:
+      file_extension: rep
+    Schedule:
+      file_extension: seq
+    Transitions:
+      file_extension: trn
+    Yields:
+      file_extension: yld

--- a/ws3/forest.py
+++ b/ws3/forest.py
@@ -2240,11 +2240,16 @@ class ForestModel:
             data = f.read()
         _data = _search(r'\*THEME.*', data, 'landscape section (no *THEME declaration found)',
                         re.M | re.S).group(0) # strip leading junk
-        t_data = re.split(r'\*THEME.*\n', _data)[1:] # split into theme-wise chunks
-        for ti, t in enumerate(t_data, start=ti_offset):
+        # Capture the text trailing each *THEME declaration rather than discarding it.
+        # That text is the modeller's own description of the theme (e.g. "Analysis Unit
+        # (AU)"), and it is the only thing in the dataset that says what a theme position
+        # means -- theme order and meaning are entirely user-defined in this format.
+        _chunks = re.split(r'\*THEME(.*)\n', _data)[1:] # [desc, body, desc, body, ...]
+        t_data = list(zip(_chunks[::2], _chunks[1::2]))
+        for ti, (t_description, t) in enumerate(t_data, start=ti_offset):
             self._themes.append({})
             self._themes[-1]['__name__'] = 'theme%i' % ti
-            self._themes[-1]['__description__'] = '' # TO DO: extract comments in theme declaration
+            self._themes[-1]['__description__'] = t_description.strip().lstrip(';').strip()
             self._theme_basecodes.append([])
             defining_aggregates = False
             for l in [l for l in t.split('\n') if not re.match(r'^\s*(;|{|$)', l)]:

--- a/ws3/woodstock.py
+++ b/ws3/woodstock.py
@@ -1,0 +1,333 @@
+"""
+The Woodstock input data format contract, and what ws3 does with it.
+
+The Woodstock format is deliberately open ended. A model instance declares its
+own set of themes, in its own order, with its own stratification variable codes
+within each theme, and the LANDSCAPE section is the authoritative source for all
+of it. Much of ws3's internal complexity follows from that flexibility.
+
+ws3 implements an essential subset of the format -- enough to have carried real
+projects for years -- but the boundary of that subset was previously undocumented
+and unenforced. Keywords outside it are not rejected; they are *ignored*. A
+dataset can declare an OPTIMIZE section, or use ``*ACTIONSERIES``, and import
+without complaint, producing a model that is quietly not the model that was
+written. No error, wrong answer.
+
+This module exists to make that boundary visible:
+
+- :py:func:`contract` loads the machine-readable keyword contract shipped as
+  package data.
+- :py:func:`lint_dataset` reports which parts of a dataset ws3 will not read.
+
+Linting is advisory and reads nothing but the files. It never mutates a model,
+and it is not required in order to import one.
+
+Two ws3 divergences from Woodstock are recorded in the contract rather than
+treated as defects:
+
+**Time unit.** Woodstock measures stand age and action timing in periods; ws3
+measures them in years. Any keyword documented as taking a number of periods --
+``_LOCK`` most visibly -- is therefore not directly comparable between the two.
+
+**Theme indexing.** Woodstock counts themes from one and writes ``_THn``
+accordingly; ws3 stores themes zero-indexed, so ``_THn`` is ws3 theme ``n-1``.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from functools import lru_cache
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+#: Location of the contract, shipped as package data.
+CONTRACT_PATH = Path(__file__).parent / 'data' / 'woodstock_format.yaml'
+
+#: What ws3 does with each section: the importer, and whether it does anything.
+#:
+#: ``stub`` is called out separately from ``none`` because the failure mode
+#: differs in a way that matters. A stub method exists and can be called
+#: successfully, so a caller has every reason to believe the section was read.
+#: It was not.
+SECTION_SUPPORT: dict[str, tuple[Optional[str], str]] = {
+    'Landscape': ('import_landscape_section', 'implemented'),
+    'Areas': ('import_areas_section', 'implemented'),
+    'Yields': ('import_yields_section', 'implemented'),
+    'Transitions': ('import_transitions_section', 'implemented'),
+    'Outputs': ('import_outputs_section', 'implemented'),
+    'Constants': ('import_constants_section', 'implemented'),
+    'Schedule': ('import_schedule_section', 'implemented'),
+    'Actions': ('import_actions_section', 'partial'),
+    'Control': ('import_control_section', 'stub'),
+    'Optimize': ('import_optimize_section', 'stub'),
+    'Graphics': ('import_graphics_section', 'stub'),
+    'Lifespan': ('import_lifespan_section', 'stub'),
+    'Regimes': (None, 'none'),
+    'Reports': (None, 'none'),
+    'Queue': (None, 'none'),
+    'Allocation': (None, 'none'),
+    'LpSchedule': (None, 'none'),
+}
+
+#: Keywords ws3 reads.
+#:
+#: Maintained here, by hand, rather than derived by searching the source for
+#: literal tokens. That approach does not work: ``import_outputs_section``
+#: recognises ``_AREA`` and ``_INVENT`` through a generic ``startswith('_')``
+#: check, so there is no literal to find, and a token search reported two
+#: working keywords as unsupported. Anything added to an importer must be added
+#: here too; :py:mod:`tests.test_woodstock` guards the parts that can be checked.
+SUPPORTED_KEYWORDS: frozenset[str] = frozenset({
+    # import_landscape_section
+    '*THEME', '*AGGREGATE',
+    # import_areas_section, standard positional form
+    '*A',
+    # import_yields_section
+    '*Y', '*YC', '*YT', '_AGE',
+    # complex yield functions resolved by the yields importer
+    '_SUM',
+    # import_actions_section
+    '*ACTION', '*OPERABLE', '*PARTIAL', '_TH', '@AGE', '@YLD',
+    # import_transitions_section
+    '*CASE', '*SOURCE', '*TARGET', '_LOCK', '_REPLACE', '_APPEND',
+    # outputs buffer resolver, including the built-in inventory keywords
+    '*OUTPUT', '*LEVEL', '*GROUP', '_AREA', '_INVENT',
+})
+
+#: Deliberate departures from Woodstock semantics, recorded so that they are not
+#: mistaken for defects.
+DIVERGENCES: dict[str, str] = {
+    'time_unit': (
+        'Woodstock measures stand age and action timing in periods. ws3 measures '
+        'them in years. ForestModel.import_areas_section takes '
+        'convert_periods_to_years and multiplies imported ages by the period '
+        'length. Any keyword documented as taking a number of periods, _LOCK '
+        'most visibly, is therefore not directly comparable between the two.'
+    ),
+    'theme_indexing': (
+        'Woodstock counts themes from one and writes _THn accordingly. ws3 '
+        'stores themes zero-indexed, so _THn refers to ws3 theme n-1.'
+    ),
+}
+
+#: Tokens that look like keywords but are format punctuation rather than
+#: keywords, and would otherwise be reported on every line of a mask.
+_NOT_KEYWORDS = {'*', '?'}
+
+#: A Woodstock keyword: a sigil followed by a name. Function-style keywords such
+#: as ``_SUM(...)`` are matched without their parentheses.
+_KEYWORD = re.compile(r'(?<![\w])([*_@][A-Za-z][A-Za-z0-9]*)')
+
+
+@dataclass(frozen=True)
+class Finding:
+    """
+    One thing ws3 will not read from a dataset.
+
+    :param severity: ``error`` when data is silently dropped, ``warning`` when a
+        keyword is unrecognised, ``info`` for advisory notes.
+    :param section: Section identifier, e.g. ``Yields``.
+    :param path: File the finding refers to, if any.
+    :param line: 1-based line number, if the finding is line-specific.
+    :param keyword: Keyword involved, if the finding is keyword-specific.
+    :param message: What ws3 will do, stated plainly.
+    """
+
+    severity: str
+    section: str
+    message: str
+    path: Optional[str] = None
+    line: Optional[int] = None
+    keyword: Optional[str] = None
+
+    def __str__(self) -> str:
+        where = self.path or self.section
+        if self.line is not None:
+            where = f'{where}:{self.line}'
+        return f'{self.severity}: {where}: {self.message}'
+
+
+@lru_cache(maxsize=1)
+def contract() -> dict[str, Any]:
+    """
+    Load the Woodstock format contract.
+
+    Cached, because it is read-only reference data and parsing it repeatedly
+    inside a lint loop would be wasteful.
+
+    :raises FileNotFoundError: If the package data is missing, which means an
+        incomplete installation rather than a user error.
+    """
+    import yaml
+
+    if not CONTRACT_PATH.is_file():
+        raise FileNotFoundError(
+            f'The Woodstock format contract is missing from the installed '
+            f'package (expected at {CONTRACT_PATH}). Reinstall ws3.'
+        )
+    with open(CONTRACT_PATH) as f:
+        return yaml.safe_load(f)
+
+
+def sections() -> dict[str, dict[str, Any]]:
+    """Section identifiers mapped to their contract entry, e.g. file extension."""
+    return contract()['meta']['sections']
+
+
+def keywords() -> dict[str, dict[str, Any]]:
+    """Every catalogued keyword, mapped to its contract entry."""
+    return contract()['keywords']
+
+
+def supported_keywords() -> frozenset[str]:
+    """Keywords ws3 reads. See :py:data:`SUPPORTED_KEYWORDS`."""
+    return SUPPORTED_KEYWORDS
+
+
+def section_support(name: str) -> tuple[Optional[str], str]:
+    """
+    The importer for a section and whether it does anything.
+
+    :return: ``(importer_name, status)`` where status is one of ``implemented``,
+        ``partial``, ``stub`` or ``none``.
+    """
+    return SECTION_SUPPORT.get(name, (None, 'none'))
+
+
+def canonical(token: str) -> str:
+    """
+    Reduce a keyword token to its contract spelling.
+
+    Indexed keywords appear in real files with a number (``_TH1``) but are
+    catalogued under a placeholder (``_THn``), and the contract stores the
+    placeholder stripped. Normalising both sides means a keyword has one
+    spelling everywhere, which is what makes the support set checkable.
+    """
+    return re.sub(r'^([*_@]TH)(?:n|\d+)$', r'\1', token)
+
+
+def _scan_keywords(text: str) -> list[tuple[int, str]]:
+    """
+    Find keyword tokens in a section file, with line numbers.
+
+    Comments are stripped first: Woodstock comments start with ``;`` and run to
+    end of line, and prose in a comment should not be reported as a keyword.
+    """
+    found = []
+    for number, raw in enumerate(text.splitlines(), start=1):
+        line = raw.partition(';')[0]
+        if not line.strip():
+            continue
+        for match in _KEYWORD.finditer(line):
+            token = match.group(1)
+            if token in _NOT_KEYWORDS:
+                continue
+            found.append((number, canonical(token)))
+    return found
+
+
+def lint_dataset(
+    model_path: str,
+    model_name: str,
+    sections_to_check: Optional[Iterable[str]] = None,
+) -> list[Finding]:
+    """
+    Report what ws3 will not read from a Woodstock dataset.
+
+    Reads the section files directly. Nothing is imported, no model is built,
+    and nothing is modified -- so this is safe to run before deciding whether to
+    trust an import.
+
+    Findings are ordered by severity, then by file, then by line.
+
+    :param model_path: Directory holding the section files.
+    :param model_name: Base file name shared by the section files.
+    :param sections_to_check: Restrict to these section identifiers. Defaults to
+        every section in the contract.
+    :return: Findings, empty when ws3 reads everything present.
+    """
+    base = Path(model_path)
+    all_sections = sections()
+    wanted = set(sections_to_check) if sections_to_check else set(all_sections)
+    known = keywords()
+    supported = supported_keywords()
+
+    findings: list[Finding] = []
+
+    for name in sorted(wanted):
+        spec = all_sections.get(name)
+        if spec is None:
+            continue
+        extension = spec.get('file_extension')
+        if not extension:
+            continue
+
+        path = base / f'{model_name}.{extension}'
+        if not path.is_file():
+            continue
+
+        try:
+            text = path.read_text(errors='replace')
+        except OSError as exc:
+            findings.append(Finding(
+                severity='warning', section=name, path=str(path),
+                message=f'could not be read: {exc}',
+            ))
+            continue
+
+        support = section_support(name)[1]
+        if support in ('stub', 'none'):
+            importer = section_support(name)[0]
+            detail = (
+                'ws3 has no importer for it'
+                if not importer else
+                f'{importer} is a stub and imports nothing'
+            )
+            findings.append(Finding(
+                severity='error', section=name, path=str(path),
+                message=(
+                    f'the {name.upper()} section is present but not imported: '
+                    f'{detail}. Everything in this file is ignored.'
+                ),
+            ))
+            # No point listing individual keywords in a file that is wholly
+            # ignored; the section-level finding already says so.
+            continue
+
+        seen: set[str] = set()
+        for line, token in _scan_keywords(text):
+            if token in supported or token in seen:
+                continue
+            entry = known.get(token)
+            if entry is None:
+                # Unknown to the contract entirely. Most likely a theme code or
+                # yield name that happens to start with a sigil, so this is
+                # advisory rather than an error.
+                continue
+            seen.add(token)
+            findings.append(Finding(
+                severity='warning', section=name, path=str(path), line=line,
+                keyword=token,
+                message=(
+                    f'{token} is a documented Woodstock keyword that ws3 does '
+                    f'not import; it is ignored'
+                ),
+            ))
+
+    order = {'error': 0, 'warning': 1, 'info': 2}
+    findings.sort(key=lambda f: (order.get(f.severity, 3), f.path or '', f.line or 0))
+    return findings
+
+
+def format_findings(findings: Iterable[Finding]) -> str:
+    """Render findings as a readable report."""
+    findings = list(findings)
+    if not findings:
+        return 'No findings: ws3 imports everything present in this dataset.'
+    lines = [str(f) for f in findings]
+    errors = sum(1 for f in findings if f.severity == 'error')
+    warnings = sum(1 for f in findings if f.severity == 'warning')
+    lines.append('')
+    lines.append(f'{errors} section(s) not imported, {warnings} keyword(s) ignored.')
+    return '\n'.join(lines)


### PR DESCRIPTION
Closes #114.

## What this does

ws3 imports an essential subset of the Woodstock model input data format. Until
now the boundary of that subset was invisible: keywords outside it are not
rejected, they are *ignored*. A dataset could declare an `OPTIMIZE` section, or
use `*ACTIONSERIES`, and import without complaint — producing a model that was
quietly not the model that was written. No error, wrong answer. That is the same
defect class as a silently wrong yield expression.

This phase makes the boundary machine-readable, checkable, and documented.

## Changes

**P9.1 — keyword contract as package data (#115)**
`ws3/data/woodstock_format.yaml` catalogues 198 keywords across 17 sections and
ships with the package. Loads offline, contains no vendor prose. Exposed through
`ws3.woodstock` (`keywords()`, `sections()`, `supported_keywords()`,
`section_support()`, `DIVERGENCES`).

**P9.2 — theme descriptions preserved on import (#116)**
A `*THEME` line carries a descriptive name, and that description is the only
statement in a dataset of what a theme position means. It used to be discarded.
`import_landscape_section` now keeps it as `__description__` on each entry of
`ForestModel._themes`. Where a dataset omits it, ws3 says so rather than
inventing a meaning.

**P9.3 — dataset linter (#117)**
`ws3.woodstock.lint_dataset` reports what ws3 will not read from a dataset: file,
line, section, keyword, severity. It reads the section files directly — nothing
is imported, no model is built, nothing is modified. Advisory, not required in
order to import.

Support is declared beside the importers rather than derived by grepping the
source, because it cannot be derived that way: `import_outputs_section`
recognises `_AREA` and `_INVENT` through a generic `startswith('_')` check, and a
first attempt at token-matching reported both working keywords as unsupported.
There is a false-positive regression test for exactly this.

**P9.4 — documentation (#118)**
New reference page, *Woodstock Format: What ws3 Reads*. Its section table,
keyword table, coverage counts and divergence list are generated at build time
from `ws3.woodstock` by `docs/source/_ext/ws3_woodstock.py`, so the documented
subset cannot drift from the implemented one.

## Recorded divergences from Woodstock

Intentional, and recorded in the contract rather than treated as defects:

- **Time unit.** Woodstock measures age and action timing in periods; ws3
  measures them in years.
- **Theme indexing.** Woodstock counts themes from one (`_THn`); ws3 stores
  themes zero-indexed, so `_THn` maps to ws3 theme `n-1`.

## Measured support

| Support | Sections |
| --- | --- |
| implemented | Landscape, Areas, Yields, Transitions, Outputs, Constants, Schedule |
| partial | Actions |
| stub — method exists, imports nothing | Optimize, Control, Graphics, Lifespan |
| absent | Regimes, Reports, Queue, Allocation, LpSchedule |

`stub` is called out separately from `absent` because the failure mode differs:
a stub returns successfully, so a caller has every reason to believe the section
was read.

Run against the bundled `tsa24_clipped` dataset, the linter reports five section
files that are read by nobody (`.lif`, `.opt`, `.que`, `.rep`, `.run`). That is
not a defect report — the model built from that dataset has carried real work —
but it is the difference between knowing that and assuming otherwise.

## Verification

```bash
python -m pytest
python -m sphinx -b html docs/source /tmp/ws3docs -W --keep-going
python -c "from ws3 import woodstock as w; print(len(w.keywords()), len(w.supported_keywords()), len(w.sections()))"
```

- `273 passed, 9 skipped`
- Contract counts `198 25 17`, matching the figures in `ROADMAP.md`,
  `CHANGELOG.md` and the generated documentation

## Known pre-existing debt, not addressed here

The parent issue's acceptance criteria named `ruff check .` and a `-W` docs
build. Neither passes on this branch, and neither passed on `main` beforehand:

- `ruff` reports 2042 style findings repository-wide.
- The docs tree emits 39 warnings — broken `:doc:` targets under
  `docs/source/textbook/`, unescaped inline markup in
  `examples/078_ws3_advanced_modeling.ipynb`, notebooks outside any toctree.

Phase 9 introduces none of them, and none of the 39 warnings reference the files
added here. Flagging rather than quietly dropping the criterion; clearing this
debt is worth its own phase.

## Behaviour changes

Additive. `lint_dataset` is advisory and touches nothing. The only change to
existing import behaviour is that `import_landscape_section` now retains a theme
description it previously threw away.
